### PR TITLE
Add X10 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Since Siri supports devices added through HomeKit, this means that with HomeBrid
  * _Siri, turn off the Speakers._ ([Sonos](http://www.sonos.com))
  * _Siri, turn on the Dehumidifier._ ([WeMo](http://www.belkin.com/us/Products/home-automation/c/wemo-home-automation/))
  * _Siri, turn on Away Mode._ ([Xfinity Home](http://www.comcast.com/home-security.html))
+ * _Siri, turn on the living room lights._ ([X10 via rest-mochad](http://github.com/edc1591/rest-mochad))
 
 If you would like to support any other devices, please write a shim and create a pull request and I'd be happy to add it to this official list.
 

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -130,7 +130,7 @@ X10.prototype = {
       }]
     }];
     if (that.canDim) {
-      services.characteristics.push({
+      services[0].characteristics.push({
         cType: types.BRIGHTNESS_CTYPE,
         onUpdate: function(value) { that.setBrightnessLevel(value); },
         perms: ["pw","pr","ev"],

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -18,7 +18,6 @@ X10.prototype = {
     var that = this;
     
     this.log("Setting power state of " + this.deviceID + " to " + powerOn);
-    this.log("http://"+this.ip_address+"/x10/"+this.deviceID+"/power/"+binaryState+"?protocol="+this.protocol);
     request.put({
       url: "http://"+this.ip_address+"/x10/"+this.deviceID+"/power/"+binaryState+"?protocol="+this.protocol,
     }, function(err, response, body) {

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -1,0 +1,152 @@
+var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var request = require("request");
+
+function X10(log, config) {
+  this.log = log;
+  this.ip_address = config["ip_address"];
+  this.name = config["name"];
+  this.deviceID = config["device_id"];
+  this.protocol = config["protocol"];
+  this.canDim = config["can_dim"];
+}
+
+X10.prototype = {
+
+  setPowerState: function(powerOn) {
+
+    var binaryState = powerOn ? "on" : "off";
+    var that = this;
+    
+    this.log("Setting power state of " + this.deviceID + " to " + powerOn);
+    this.log("http://"+this.ip_address+"/x10/"+this.deviceID+"/power/"+binaryState+"?protocol="+this.protocol);
+    request.put({
+      url: "http://"+this.ip_address+"/x10/"+this.deviceID+"/power/"+binaryState+"?protocol="+this.protocol,
+    }, function(err, response, body) {
+
+      if (!err && response.statusCode == 200) {
+        that.log("State change complete.");
+      }
+      else {
+        that.log("Error '"+err+"' setting power state: " + body);
+      }
+    });
+  },
+
+  setBrightnessLevel: function(value) {
+
+    var that = this;
+    
+    this.log("Setting brightness level of " + this.deviceID + " to " + value);
+    request.put({
+      url: "http://"+this.ip_address+"/x10/"+this.deviceID+"/brightness/?protocol="+this.protocol+"&value="+value,
+    }, function(err, response, body) {
+
+      if (!err && response.statusCode == 200) {
+        that.log("State change complete.");
+      }
+      else {
+        that.log("Error '"+err+"' setting brightness level: " + body);
+      }
+    });
+  },
+
+  getServices: function() {
+    var that = this;
+    var services = [{
+      sType: types.ACCESSORY_INFORMATION_STYPE,
+      characteristics: [{
+        cType: types.NAME_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+        format: "string",
+        initialValue: this.name,
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Name of the accessory",
+        designedMaxLength: 255
+      },{
+        cType: types.MANUFACTURER_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+        format: "string",
+        initialValue: "X10",
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Manufacturer",
+        designedMaxLength: 255
+      },{
+        cType: types.MODEL_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+        format: "string",
+        initialValue: "Rev-1",
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Model",
+        designedMaxLength: 255
+      },{
+        cType: types.SERIAL_NUMBER_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+        format: "string",
+        initialValue: "A1S2NASF88EW",
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "SN",
+        designedMaxLength: 255
+      },{
+        cType: types.IDENTIFY_CTYPE,
+        onUpdate: null,
+        perms: ["pw"],
+        format: "bool",
+        initialValue: false,
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Identify Accessory",
+        designedMaxLength: 1
+      }]
+    },{
+      sType: types.SWITCH_STYPE,
+      characteristics: [{
+        cType: types.NAME_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+        format: "string",
+        initialValue: this.name,
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Name of service",
+        designedMaxLength: 255
+      },{
+        cType: types.POWER_STATE_CTYPE,
+        onUpdate: function(value) { that.setPowerState(value); },
+        perms: ["pw","pr","ev"],
+        format: "bool",
+        initialValue: false,
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Change the power state of a Variable",
+        designedMaxLength: 1
+      }]
+    }];
+    if (that.canDim) {
+      services.characteristics.push({
+        cType: types.BRIGHTNESS_CTYPE,
+        onUpdate: function(value) { that.setBrightnessLevel(value); },
+        perms: ["pw","pr","ev"],
+        format: "int",
+        initialValue: 0,
+        supportEvents: false,
+        supportBonjour: false,
+        manfDescription: "Adjust Brightness of Light",
+        designedMinValue: 0,
+        designedMaxValue: 100,
+        designedMinStep: 1,
+        unit: "%"
+      });
+    }
+    return services;
+  }
+};
+
+module.exports.accessory = X10;

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -106,7 +106,7 @@ X10.prototype = {
         designedMaxLength: 1
       }]
     },{
-      sType: types.SWITCH_STYPE,
+      sType: types.LIGHTBULB_STYPE,
       characteristics: [{
         cType: types.NAME_CTYPE,
         onUpdate: null,

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -130,7 +130,7 @@ X10.prototype = {
       }]
     }];
     if (that.canDim) {
-      services[0].characteristics.push({
+      services[1].characteristics.push({
         cType: types.BRIGHTNESS_CTYPE,
         onUpdate: function(value) { that.setBrightnessLevel(value); },
         perms: ["pw","pr","ev"],

--- a/config-sample.json
+++ b/config-sample.json
@@ -50,6 +50,14 @@
             "description": "Control HomeMatic devices (The XMP-API addon for the CCU is required)",
             "ccu_id": "The XMP-API id of your HomeMatic device",
             "ccu_ip": "The IP-Adress of your HomeMatic CCU device"
+        },
+        {
+            "accessory": "X10",
+            "name": "Lamp",
+            "ip_address": "localhost:3000",
+            "device_id": "E1",
+            "protocol": "pl",
+            "can_dim": true
         }
     ]
 }


### PR DESCRIPTION
This PR adds support for controlling X10 modules via my [rest-mochad](https://github.com/edc1591/rest-mochad) app.

X10 is an old protocol for controlling lights and pretty much any appliance that plugs into an outlet. It's very popular among hobbyists in the home automatic area because it's pretty cheap. `rest-mochad` is a REST API that sits in front of `mochad`. Mochad is a command-line utility that interfaces with a couple different X10 controllers (which transmit commands to the actual modules that are connected to the lights).

I've tested this pretty extensively and it works pretty well. Let me know if you have any questions. Thanks!