### PR TITLE
Philips Hue integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Node
 node_modules/
 npm-debug.log
+.node-version
 
 # Intellij
 .idea/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Since Siri supports devices added through HomeKit, this means that with HomeBrid
  * _Siri, turn off the Speakers._ ([Sonos](http://www.sonos.com))
  * _Siri, turn on the Dehumidifier._ ([WeMo](http://www.belkin.com/us/Products/home-automation/c/wemo-home-automation/))
  * _Siri, turn on Away Mode._ ([Xfinity Home](http://www.comcast.com/home-security.html))
- * _Siri, turn on the living room lights._ ([Wink](http://www.wink.com), [SmartThings](http://www.smartthings.com), [X10](http://github.com/edc1591/rest-mochad))
+ * _Siri, turn on the living room lights._ ([Wink](http://www.wink.com), [SmartThings](http://www.smartthings.com), [X10](http://github.com/edc1591/rest-mochad), [Philips Hue](http://meethue.com))
 
 If you would like to support any other devices, please write a shim and create a pull request and I'd be happy to add it to this official list.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Now you should be able to run the homebridge server:
     Starting HomeBridge server...
     Couldn't find a config.json file [snip]
 
-The server won't do anything until you've created a `config.json` file containing your home devices (or _accessories_ in HomeKit parlance) or platforms you wish to make available to iOS.
+The server won't do anything until you've created a `config.json` file containing your home devices (or _accessories_ in HomeKit parlance) or platforms you wish to make available to iOS. You can start by copying and modifying the included `config-sample.json` file which includes declarations for all supported accessories and platforms.
 
 Once you've added your devices and/or platforms, you should be able to run the server again and see them initialize:
 

--- a/README.md
+++ b/README.md
@@ -93,21 +93,9 @@ Your server is now ready to receive commands from iOS.
 
 HomeKit is actually not an app; it's a "database" similar to HealthKit and PassKit. But where HealthKit has the companion _Health_ app and PassKit has _Passbook_, Apple has supplied no app for managing your HomeKit database (at least [not yet](http://9to5mac.com/2015/05/20/apples-planned-ios-9-home-app-uses-virtual-rooms-to-manage-homekit-accessories/)). However, the HomeKit API is open for developers to write their own apps for adding devices to HomeKit.
 
-## The Easy Way - MyTouchHome
+Fortunately, there are now a few apps in the App Store that can manage your HomeKit devices. Try [Insteon+](https://itunes.apple.com/US/app/id919270334?mt=8) or [Lutron](https://itunes.apple.com/us/app/lutron-app-for-caseta-wireless/id886753021?mt=8) or a number of others.
 
-Fortunately, there is at least one app that has slipped into the App Store that can manage your HomeKit devices. It's called [MyTouchHome](http://mytouchhome.webs.com) and it costs $2. This is by far the easiest way to get up and running.
-
-You might also want to do a quick search in the App Store for "HomeKit" and see if any better/free options have popped up since the time of this writing.
-
-## The Hard Way - Building your own HomeKit iOS app
-
-Alternatively, if you have an Apple Developer account, you can build and run your own HomeKit iOS app. This is a lot of work but it's also free (if you happen to have a $99 Apple Developer account already).
-
-There are a few open-source apps out there that let you manage your HomeKit database, but the best one I've found is [BetterHomeKit](https://github.com/KhaosT/HomeKit-Demo), also made by [KhaosT](http://twitter.com/khaost).
-
-The tricky part is that, in order to run an app that uses HomeKit on your phone, you'll need to register your own unique App ID in the Apple Developer Portal, as if you were planning to submit this app to the App Store, and you'll need to enable the HomeKit "service" for that App ID in the Apple Developer Portal (similar to Game Center). You'll need to pick your own unique Bundle ID as well (like `com.yourdomain.HomeKitApp`), and actually _change_ the BetterHomeKit `Info.plist` to use that bundle ID instead of the default `org.oltica.BetterHomeKit`.
-
-## Adding Devices
+## Adding HomeKit Accessories
 
 Once you've gotten a HomeKit app running on your iOS device, you can begin adding accessories. The app should "discover" the accessories defined in your `config.json` file, assuming that you're still running the HomeBridge server and you're on the same Wifi network.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Your server is now ready to receive commands from iOS.
 
 # Adding your devices to iOS
 
-HomeKit is actually not an app; it's a "database" similar to HealthKit and PassKit. But where HealthKit has the companion _Health_ app and PassKit has _Passbook_, Apple has supplied no app for managing your HomeKit database (yet). However, the HomeKit API is open for developers to write their own apps for adding devices to HomeKit.
+HomeKit is actually not an app; it's a "database" similar to HealthKit and PassKit. But where HealthKit has the companion _Health_ app and PassKit has _Passbook_, Apple has supplied no app for managing your HomeKit database (at least [not yet](http://9to5mac.com/2015/05/20/apples-planned-ios-9-home-app-uses-virtual-rooms-to-manage-homekit-accessories/)). However, the HomeKit API is open for developers to write their own apps for adding devices to HomeKit.
 
 ## The Easy Way - MyTouchHome
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Since Siri supports devices added through HomeKit, this means that with HomeBrid
  * _Siri, turn off the Speakers._ ([Sonos](http://www.sonos.com))
  * _Siri, turn on the Dehumidifier._ ([WeMo](http://www.belkin.com/us/Products/home-automation/c/wemo-home-automation/))
  * _Siri, turn on Away Mode._ ([Xfinity Home](http://www.comcast.com/home-security.html))
- * _Siri, turn on the living room lights._ ([X10 via rest-mochad](http://github.com/edc1591/rest-mochad) or [Wink via wink-js](https://github.com/winfinit/wink-js))
+ * _Siri, turn on the living room lights._ ([Wink](http://www.wink.com), [SmartThings](http://www.smartthings.com), [X10](http://github.com/edc1591/rest-mochad))
 
 If you would like to support any other devices, please write a shim and create a pull request and I'd be happy to add it to this official list.
 
@@ -28,8 +28,6 @@ Accessories are individual devices you would like to bridge to HomeKit. You set 
 ## Platforms
 
 Platforms bridge entire systems to HomeKit. Platforms can be things like Wink or SmartThings or Vera. By adding a platform to your `config.json`, HomeBridge will automatically detect all of your devices for you.
-
-    Wink is currently the only supported platform at the moment.
 
 All you have to do is add the right config options so HomeBridge can authenticate and communicate with your other system, and voila, your devices will be available to HomeKit via HomeBridge.
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -22,6 +22,12 @@
             "server": "127.0.0.1",
             "port": "8005"
         }
+        {
+            "platform": "PhilipsHue",
+            "name": "Phillips Hue",
+            "ip_address": "127.0.0.1",
+            "username": "252deadbeef0bf3f34c7ecb810e832f"
+        }
     ],
 
     "accessories": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "request": "2.49.x",
     "node-persist": "0.0.x",
     "xmldoc": "0.1.x",
-
+    "node-hue-api": "^1.0.5",
     "carwingsjs": "0.0.x",
     "sonos": "0.8.x",
     "wemo": "0.2.x",

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -54,7 +54,7 @@ var locateBridge = function (callback) {
     }
 
     if (bridges.length > 1) {
-      that.log("Warning: Multiple Philips Hue bridges detected. The first bridge will be used automatically. To use a different bridge set ip_address manually in configuration.");
+      that.log("Warning: Multiple Philips Hue bridges detected. The first bridge will be used automatically. To use a different bridge, set the `ip_address` manually in the configuration.");
     }
 
     that.log(
@@ -72,7 +72,7 @@ var locateBridge = function (callback) {
   that.log("Attempting to discover Philips Hue bridge with meethue.com...");
   hue.nupnpSearch(function (locateError, bridges) {
     if (locateError) {
-      that.log("Philips Hue bridge discovery with meethue.com failed. Register your bridge with the meethue.com for more reiable discovery.");
+      that.log("Philips Hue bridge discovery with meethue.com failed. Register your bridge with the meethue.com for more reliable discovery.");
 
       that.log("Attempting to discover Philips Hue bridge with network scan...");
 
@@ -94,9 +94,9 @@ var locateBridge = function (callback) {
 
 PhilipsHuePlatform.prototype = {
   accessories: function(callback) {
+    this.log("Fetching Philips Hue lights...");
     var that = this;
     var getLights = function () {
-      that.log("Fetching Philips Hue lights...");
       var api = new HueApi(that.ip_address, that.username);
       // Connect to the API and loop through lights
       api.lights(function(err, response) {

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -1,0 +1,209 @@
+// Philips Hue Platform Shim for HomeBridge
+//
+// Remember to add platform to config.json. Example:
+// "platforms": [
+//     {
+//         "platform": "PhilipsHue",
+//         "name": "Philips Hue",
+//         "ip_address": "127.0.0.1",
+//         "username": "252deadbeef0bf3f34c7ecb810e832f"
+//     }
+// ],
+//
+// When you attempt to add a device, it will ask for a "PIN code".
+// The default code for all HomeBridge accessories is 031-45-154.
+//
+
+/* jslint node: true */
+/* globals require: false */
+/* globals config: false */
+
+"use strict";
+
+var types = require("../lib/HAP-NodeJS/accessories/types.js");
+
+function PhilipsHuePlatform(log, config) {
+  this.log     = log;
+  this.ip_address  = config["ip_address"];
+  this.username    = config["username"];
+}
+
+function PhilipsHueAccessory(log, accessoryName, philipsHueLightID, model, philipsHueLightNumber) {
+  return {
+    displayName: accessoryName,
+    username: philipsHueLightID,
+    pincode: '031-45-154',
+    services: [{
+      sType: types.ACCESSORY_INFORMATION_STYPE,
+      characteristics: [{
+        cType: types.NAME_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+      format: "string",
+      initialValue: accessoryName,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Name of the accessory",
+      designedMaxLength: 255
+      },{
+        cType: types.MANUFACTURER_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+      format: "string",
+      initialValue: "Philips",
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Manufacturer",
+      designedMaxLength: 255
+      },{
+        cType: types.MODEL_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+      format: "string",
+      initialValue: model,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Model",
+      designedMaxLength: 255
+      },{
+        cType: types.IDENTIFY_CTYPE,
+        onUpdate: function(value) { console.log("Change:",value); execute(accessoryName, philipsHueLightNumber, "identify", value); },
+        perms: ["pw"],
+      format: "bool",
+      initialValue: false,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Identify Accessory",
+      designedMaxLength: 1
+      }]
+    },{
+      sType: types.LIGHTBULB_STYPE,
+      characteristics: [{
+        cType: types.NAME_CTYPE,
+        onUpdate: null,
+        perms: ["pr"],
+      format: "string",
+      initialValue: accessoryName,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Name of service",
+      designedMaxLength: 255
+      },{
+        cType: types.POWER_STATE_CTYPE,
+        onUpdate: function(value) { console.log("Change:",value); execute(accessoryName, philipsHueLightNumber, "on", value); },
+        perms: ["pw","pr","ev"],
+      format: "bool",
+      initialValue: false,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Turn On the Light",
+      designedMaxLength: 1
+      },{
+        cType: types.HUE_CTYPE,
+        onUpdate: function(value) { console.log("Change:",value); execute(accessoryName, philipsHueLightNumber, "hue", value); },
+        perms: ["pw","pr","ev"],
+      format: "int",
+      initialValue: 0,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Adjust Hue of Light",
+      designedMinValue: 0,
+      designedMaxValue: 65535,
+      designedMinStep: 1,
+      unit: "arcdegrees"
+      },{
+        cType: types.BRIGHTNESS_CTYPE,
+        onUpdate: function(value) { console.log("Change:",value); execute(accessoryName, philipsHueLightNumber, "brightness", value); },
+        perms: ["pw","pr","ev"],
+      format: "int",
+      initialValue: 0,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Adjust Brightness of Light",
+      designedMinValue: 0,
+      designedMaxValue: 100,
+      designedMinStep: 1,
+      unit: "%"
+      },{
+        cType: types.SATURATION_CTYPE,
+        onUpdate: function(value) { console.log("Change:",value); execute(accessoryName, philipsHueLightNumber, "saturation", value); },
+        perms: ["pw","pr","ev"],
+      format: "int",
+      initialValue: 0,
+      supportEvents: false,
+      supportBonjour: false,
+      manfDescription: "Adjust Saturation of Light",
+      designedMinValue: 0,
+      designedMaxValue: 100,
+      designedMinStep: 1,
+      unit: "%"
+      }]
+    }]
+  };
+}
+
+var execute = function(accessory, lightID, characteristic, value) {
+  var http = require('http');
+  var body = {};
+  characteristic = characteristic.toLowerCase();
+  if(characteristic === "identify") {
+    body = {alert:"select"};
+  } else if(characteristic === "on") {
+    body = {on:value};
+  } else if(characteristic === "hue") {
+    body = {hue:value};
+  } else  if(characteristic === "brightness") {
+    value = value/100;
+    value = value*255;
+    value = Math.round(value);
+    body = {bri:value};
+  } else if(characteristic === "saturation") {
+    value = value/100;
+    value = value*255;
+    value = Math.round(value);
+    body = {sat:value};
+  }
+  var post_data = JSON.stringify(body);
+  var post_options = {
+    host: config["ip_address"],
+    port: '80',
+    path: '/api/' + config["username"] + '/lights/' + lightID + '/state/',
+    method: 'PUT',
+    headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': post_data.length
+    }
+  };
+  var post_req = http.request(post_options, function(res) {
+    res.setEncoding('utf8');
+    res.on('data', function (chunk) {
+        console.log('Response: ' + chunk);
+    });
+  });
+  post_req.write(post_data);
+  post_req.end();
+  console.log("executed accessory: " + accessory + ", and characteristic: " + characteristic + ", with value: " +  value + ".");
+};
+
+PhilipsHuePlatform.prototype = {
+  accessories: function(callback) {
+    this.log("Fetching Philips Hue lights...");
+
+    var that = this;
+    var foundAccessories = [];
+
+    var HueApi = require("node-hue-api").HueApi;
+    var api = new HueApi(this.ip_address, this.username);
+
+    // Connect to the API and loop through lights
+    api.lights(function(err, response) {
+      response.lights.map(function(s) {
+        var accessory = new PhilipsHueAccessory(that.log, s.name, s.uniqueid, s.modelid, s.id);
+        foundAccessories.push(accessory);
+      });
+      callback(foundAccessories);
+    });
+  }
+};
+
+module.exports.platform = PhilipsHuePlatform;

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -33,7 +33,6 @@ function PhilipsHuePlatform(log, config) {
 }
 
 function PhilipsHueAccessory(log, device, api) {
-  // device info
   this.name = device.name;
   this.model = device.modelid;
   this.device = device;
@@ -46,18 +45,22 @@ var execute = function(accessory, lightID, characteristic, value) {
   var http = require('http');
   var body = {};
   characteristic = characteristic.toLowerCase();
-  if(characteristic === "identify") {
+  if (characteristic === "identify") {
     body = {alert:"select"};
-  } else if(characteristic === "on") {
+  }
+  else if (characteristic === "on") {
     body = {on:value};
-  } else if(characteristic === "hue") {
+  }
+  else if (characteristic === "hue") {
     body = {hue:value};
-  } else  if(characteristic === "brightness") {
+  }
+  else if (characteristic === "brightness") {
     value = value/100;
     value = value*255;
     value = Math.round(value);
     body = {bri:value};
-  } else if(characteristic === "saturation") {
+  }
+  else if (characteristic === "saturation") {
     value = value/100;
     value = value*255;
     value = Math.round(value);
@@ -107,7 +110,7 @@ PhilipsHuePlatform.prototype = {
 };
 
 PhilipsHueAccessory.prototype = {
-
+  // Set Power State
   setPowerState: function(powerOn) {
     if (!this.device) {
       this.log("No '"+this.name+"' device found (yet?)");
@@ -123,23 +126,26 @@ PhilipsHueAccessory.prototype = {
       that.api.setLightState(that.id, state, function(err, result) {
         if (err) {
           that.log("Error setting power state on for '"+that.name+"'");
-        } else {
+        }
+        else {
           that.log("Successfully set power state on for '"+that.name+"'");
         }
       });
-    }else{
+    }
+    else {
       this.log("Setting power state on the '"+this.name+"' to off");
       state = lightState.create().off();
       that.api.setLightState(that.id, state, function(err, result) {
         if (err) {
           that.log("Error setting power state off for '"+that.name+"'");
-        } else {
+        }
+        else {
           that.log("Successfully set power state off for '"+that.name+"'");
         }
       });
     }
   },
-
+  // Set Brightness
   setBrightness: function(level) {
     if (!this.device) {
       this.log("No '"+this.name+"' device found (yet?)");
@@ -147,17 +153,20 @@ PhilipsHueAccessory.prototype = {
     }
 
     var that = this;
+    var state;
 
     this.log("Setting brightness on the '"+this.name+"' to " + level);
-    this.device.brightness(level, function(response) {
-      if (response === undefined) {
-        that.log("Error setting brightness on the '"+that.name+"'");
-      } else {
-        that.log("Successfully set brightness on the '"+that.name+"' to " + level);
+    state = lightState.create().brightness(level);
+    that.api.setLightState(that.id, state, function(err, result) {
+      if (err) {
+        that.log("Error setting brightness for '"+that.name+"'");
+      }
+      else {
+        that.log("Successfully set brightness for '"+that.name+"'");
       }
     });
   },
-
+  // Get Services
   getServices: function() {
     var that = this;
     return [{

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -159,112 +159,128 @@ PhilipsHueAccessory.prototype = {
   // Get Services
   getServices: function() {
     var that = this;
-    return [{
-      sType: types.ACCESSORY_INFORMATION_STYPE,
-      characteristics: [{
-        cType: types.NAME_CTYPE,
-        onUpdate: null,
-        perms: ["pr"],
-      format: "string",
-      initialValue: this.name,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Name of the accessory",
-      designedMaxLength: 255
+    return [
+      {
+        sType: types.ACCESSORY_INFORMATION_STYPE,
+        characteristics: [
+          {
+            cType: types.NAME_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: this.name,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Name of the accessory",
+            designedMaxLength: 255
+          },{
+            cType: types.MANUFACTURER_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: "Philips",
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Manufacturer",
+            designedMaxLength: 255
+          },{
+            cType: types.MODEL_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: this.model,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Model",
+            designedMaxLength: 255
+          },{
+            cType: types.SERIAL_NUMBER_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: this.model + this.id,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "SN",
+            designedMaxLength: 255
+          },{
+            cType: types.IDENTIFY_CTYPE,
+            onUpdate: function(value) { console.log("Change:",value); execute(this.device, this.id, "identify", value); },
+            perms: ["pw"],
+            format: "bool",
+            initialValue: false,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Identify Accessory",
+            designedMaxLength: 1
+          }
+        ]
       },{
-        cType: types.MANUFACTURER_CTYPE,
-        onUpdate: null,
-        perms: ["pr"],
-      format: "string",
-      initialValue: "Philips",
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Manufacturer",
-      designedMaxLength: 255
-      },{
-        cType: types.MODEL_CTYPE,
-        onUpdate: null,
-        perms: ["pr"],
-      format: "string",
-      initialValue: this.model,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Model",
-      designedMaxLength: 255
-      },{
-        cType: types.IDENTIFY_CTYPE,
-        onUpdate: function(value) { console.log("Change:",value); execute(this.device, this.id, "identify", value); },
-        perms: ["pw"],
-      format: "bool",
-      initialValue: false,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Identify Accessory",
-      designedMaxLength: 1
-      }]
-    },{
-      sType: types.LIGHTBULB_STYPE,
-      characteristics: [{
-        cType: types.NAME_CTYPE,
-        onUpdate: null,
-        perms: ["pr"],
-      format: "string",
-      initialValue: this.name,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Name of service",
-      designedMaxLength: 255
-      },{
-        cType: types.POWER_STATE_CTYPE,
-        onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "on", value); },
-        perms: ["pw","pr","ev"],
-      format: "bool",
-      initialValue: false,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Turn On the Light",
-      designedMaxLength: 1
-      },{
-        cType: types.HUE_CTYPE,
-        onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "hue", value); },
-        perms: ["pw","pr","ev"],
-      format: "int",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Adjust Hue of Light",
-      designedMinValue: 0,
-      designedMaxValue: 65535,
-      designedMinStep: 1,
-      unit: "arcdegrees"
-      },{
-        cType: types.BRIGHTNESS_CTYPE,
-        onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "brightness", value); },
-        perms: ["pw","pr","ev"],
-      format: "int",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Adjust Brightness of Light",
-      designedMinValue: 0,
-      designedMaxValue: 100,
-      designedMinStep: 1,
-      unit: "%"
-      },{
-        cType: types.SATURATION_CTYPE,
-        onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "saturation", value); },
-        perms: ["pw","pr","ev"],
-      format: "int",
-      initialValue: 0,
-      supportEvents: false,
-      supportBonjour: false,
-      manfDescription: "Adjust Saturation of Light",
-      designedMinValue: 0,
-      designedMaxValue: 100,
-      designedMinStep: 1,
-      unit: "%"
-      }]
-    }];
+        sType: types.LIGHTBULB_STYPE,
+        characteristics: [
+          {
+            cType: types.NAME_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: this.name,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Name of service",
+            designedMaxLength: 255
+          },{
+            cType: types.POWER_STATE_CTYPE,
+            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "on", value); },
+            perms: ["pw","pr","ev"],
+            format: "bool",
+            initialValue: false,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Turn On the Light",
+            designedMaxLength: 1
+          },{
+            cType: types.HUE_CTYPE,
+            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "hue", value); },
+            perms: ["pw","pr","ev"],
+            format: "int",
+            initialValue: 0,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Adjust Hue of Light",
+            designedMinValue: 0,
+            designedMaxValue: 65535,
+            designedMinStep: 1,
+            unit: "arcdegrees"
+          },{
+            cType: types.BRIGHTNESS_CTYPE,
+            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "brightness", value); },
+            perms: ["pw","pr","ev"],
+            format: "int",
+            initialValue: 0,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Adjust Brightness of Light",
+            designedMinValue: 0,
+            designedMaxValue: 100,
+            designedMinStep: 1,
+            unit: "%"
+          },{
+            cType: types.SATURATION_CTYPE,
+            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "saturation", value); },
+            perms: ["pw","pr","ev"],
+            format: "int",
+            initialValue: 0,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Adjust Saturation of Light",
+            designedMinValue: 0,
+            designedMaxValue: 100,
+            designedMinStep: 1,
+            unit: "%"
+          }
+        ]
+      }
+    ];
   }
 };
 

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -42,6 +42,7 @@ function PhilipsHueAccessory(log, device, api) {
 }
 
 // Execute changes for various characteristics
+// @todo Move this into accessory methods
 var execute = function(api, device, characteristic, value) {
 
   var state = lightState.create();
@@ -50,8 +51,13 @@ var execute = function(api, device, characteristic, value) {
   if (characteristic === "identify") {
     state.alert('select');
   }
-  else if (characteristic === "on") {
-    state.on();
+  else if (characteristic === "power") {
+    if (value) {
+      state.on();
+    }
+    else {
+      state.off();
+    }
   }
   else if (characteristic === "hue") {
     state.hue(value);
@@ -100,62 +106,6 @@ PhilipsHuePlatform.prototype = {
 };
 
 PhilipsHueAccessory.prototype = {
-  // Set Power State
-  setPowerState: function(powerOn) {
-    if (!this.device) {
-      this.log("No '"+this.name+"' device found (yet?)");
-      return;
-    }
-
-    var that = this;
-    var state;
-
-    if (powerOn) {
-      this.log("Setting power state on the '"+this.name+"' to off");
-      state = lightState.create().on();
-      that.api.setLightState(that.id, state, function(err, result) {
-        if (err) {
-          that.log("Error setting power state on for '"+that.name+"'");
-        }
-        else {
-          that.log("Successfully set power state on for '"+that.name+"'");
-        }
-      });
-    }
-    else {
-      this.log("Setting power state on the '"+this.name+"' to off");
-      state = lightState.create().off();
-      that.api.setLightState(that.id, state, function(err, result) {
-        if (err) {
-          that.log("Error setting power state off for '"+that.name+"'");
-        }
-        else {
-          that.log("Successfully set power state off for '"+that.name+"'");
-        }
-      });
-    }
-  },
-  // Set Brightness
-  setBrightness: function(level) {
-    if (!this.device) {
-      this.log("No '"+this.name+"' device found (yet?)");
-      return;
-    }
-
-    var that = this;
-    var state;
-
-    this.log("Setting brightness on the '"+this.name+"' to " + level);
-    state = lightState.create().brightness(level);
-    that.api.setLightState(that.id, state, function(err, result) {
-      if (err) {
-        that.log("Error setting brightness for '"+that.name+"'");
-      }
-      else {
-        that.log("Successfully set brightness for '"+that.name+"'");
-      }
-    });
-  },
   // Get Services
   getServices: function() {
     var that = this;
@@ -230,7 +180,7 @@ PhilipsHueAccessory.prototype = {
             designedMaxLength: 255
           },{
             cType: types.POWER_STATE_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "on", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "power", value); },
             perms: ["pw","pr","ev"],
             format: "bool",
             initialValue: false,

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -33,6 +33,7 @@ function PhilipsHuePlatform(log, config) {
 }
 
 function PhilipsHueAccessory(log, device, api) {
+  this.id = device.id;
   this.name = device.name;
   this.model = device.modelid;
   this.device = device;

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -205,7 +205,7 @@ PhilipsHueAccessory.prototype = {
             designedMaxLength: 255
           },{
             cType: types.IDENTIFY_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(this.device, this.id, "identify", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "identify", value); },
             perms: ["pw"],
             format: "bool",
             initialValue: false,
@@ -230,7 +230,7 @@ PhilipsHueAccessory.prototype = {
             designedMaxLength: 255
           },{
             cType: types.POWER_STATE_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "on", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "on", value); },
             perms: ["pw","pr","ev"],
             format: "bool",
             initialValue: false,
@@ -240,7 +240,7 @@ PhilipsHueAccessory.prototype = {
             designedMaxLength: 1
           },{
             cType: types.HUE_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "hue", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "hue", value); },
             perms: ["pw","pr","ev"],
             format: "int",
             initialValue: 0,
@@ -253,7 +253,7 @@ PhilipsHueAccessory.prototype = {
             unit: "arcdegrees"
           },{
             cType: types.BRIGHTNESS_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "brightness", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "brightness", value); },
             perms: ["pw","pr","ev"],
             format: "int",
             initialValue: 0,
@@ -266,7 +266,7 @@ PhilipsHueAccessory.prototype = {
             unit: "%"
           },{
             cType: types.SATURATION_CTYPE,
-            onUpdate: function(value) { console.log("Change:",value); execute(this.api, this.device, "saturation", value); },
+            onUpdate: function(value) { console.log("Change:",value); execute(that.api, that.device, "saturation", value); },
             perms: ["pw","pr","ev"],
             format: "int",
             initialValue: 0,


### PR DESCRIPTION
Uses the [node-hue-api](https://github.com/peter-murray/node-hue-api) package to interact with the bridge.

I've gotten it to where the devices will start appearing in Inteon+. However, when adding it, it complains that each device "does not conform" to HomeKit and removes it. I'm mostly soliciting help at this point if anyone can salvage this PR into something that works with their bridge.

- [x] Hue devices appear in HomeKit app (Insteon+)
- [x] Hue devices add to the database (without "does not conform" error)
- [x] Hue lights can be turned off/on
- [x] Hue lights can have colors changed in-app
- [x] Hue lights can have brightness changed
- [x] Hue lux lights can be turned off/on
- [x] Hue lux lights can have brightness changed
- [x] Code is cleaned up to fully use the `node-hue-api` package (instead of direct bridge calls)
- [x] Bridges can use the `detectBridges` API endpoint to further ease setup process (stretch goal)

When it merges, it fixes #21

---

Note for development: In the event Insteon+ or other application deems the device incompatible, simply delete the `./persist` directory (will nuke other things) and they will show back up on next launch.