### PR TITLE
Read State

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,6 +123,7 @@ function createHAPServer(name, services) {
         //loop through characteristics
         for (var k = 0; k < services[j].characteristics.length; k++) {
             var options = {
+                onRead: services[j].characteristics[k].onRead,
                 type: services[j].characteristics[k].cType,
                 perms: services[j].characteristics[k].perms,
                 format: services[j].characteristics[k].format,

--- a/platforms/Wink.js
+++ b/platforms/Wink.js
@@ -209,6 +209,11 @@ WinkAccessory.prototype = {
       },{
         cType: types.POWER_STATE_CTYPE,
         onUpdate: function(value) { that.setPowerState(value); },
+        onRead: function(callback) {
+          that.getPowerState(function(powerState){
+            callback(powerState);
+          });
+        },
         perms: ["pw","pr","ev"],
         format: "bool",
         initialValue: 0,
@@ -219,6 +224,11 @@ WinkAccessory.prototype = {
       },{
         cType: types.BRIGHTNESS_CTYPE,
         onUpdate: function(value) { that.setBrightness(value); },
+        onRead: function(callback) {
+          that.getBrightness(function(level){
+            callback(level);
+          });
+        },
         perms: ["pw","pr","ev"],
         format: "int",
         initialValue:  0,

--- a/platforms/Wink.js
+++ b/platforms/Wink.js
@@ -56,6 +56,40 @@ function WinkAccessory(log, device) {
 }
 
 WinkAccessory.prototype = {
+  getPowerState: function(callback){
+    if (!this.device) {
+      this.log("No '"+this.name+"' device found (yet?)");
+      return;
+    }
+
+    var that = this;
+
+    this.log("checking power state for: " + this.name);
+    wink.user().device(this.name, function(light_obj){
+      powerState = light_obj.desired_state.powered
+      that.log("power state for " + that.name + " is: " + powerState)
+      callback(powerState);
+    });
+
+
+  },
+
+  getBrightness: function(callback){
+    if (!this.device) {
+      this.log("No '"+this.name+"' device found (yet?)");
+      return;
+    }
+
+    var that = this;
+
+    this.log("checking brightness level for: " + this.name);
+    wink.user().device(this.name, function(light_obj){
+      level = light_obj.desired_state.brightness * 100
+      that.log("brightness level for " + that.name + " is: " + level)
+      callback(level);
+    });
+
+  },
 
   setPowerState: function(powerOn) {
     if (!this.device) {

--- a/platforms/Wink.js
+++ b/platforms/Wink.js
@@ -208,7 +208,9 @@ WinkAccessory.prototype = {
         designedMaxLength: 255
       },{
         cType: types.POWER_STATE_CTYPE,
-        onUpdate: function(value) { that.setPowerState(value); },
+        onUpdate: function(value) {
+          that.setPowerState(value);
+        },
         onRead: function(callback) {
           that.getPowerState(function(powerState){
             callback(powerState);
@@ -223,7 +225,9 @@ WinkAccessory.prototype = {
         designedMaxLength: 1
       },{
         cType: types.BRIGHTNESS_CTYPE,
-        onUpdate: function(value) { that.setBrightness(value); },
+        onUpdate: function(value) {
+          that.setBrightness(value);
+        },
         onRead: function(callback) {
           that.getBrightness(function(level){
             callback(level);


### PR DESCRIPTION
:construction::construction: **Don't merge this yet, since there's some concern for missed cases being handled, as [mentioned here](https://github.com/KhaosT/HAP-NodeJS/pull/82#issuecomment-115113385).**:construction::construction:

This adds the ability to read state from accessories. With KhaosT/HAP-NodeJS#82 landed, we can now return requests for state via callbacks. This way your device lib can fetch state asynchronously. 

As an example, the Wink accessory/platform was updated to support fetching state for `poweredOn` and `brightness`.
