### PR TITLE
HTTP Shim Read States

### DIFF
--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -42,6 +42,24 @@ HttpAccessory.prototype = {
       }
     });
   },
+
+  getBrightness: function(callback){
+    if (!this.read_brightness_url) { callback(null); }
+
+    var that = this;
+    this.log("checking brightness level for: " + this.name);
+
+    this.httpRequest(this.read_powered_url, 'GET', function(error, response, body){
+      if (error) {
+        that.log('http get brightness level failed:', error);
+        callback(null)
+      }else{
+        that.log('http get brightness level succeeded!');
+        callback(body)
+      }
+    });
+  },
+
   setPowerState: function(powerOn) {
     if (!this.on_url) { return; }
     if (!this.off_url) { return; }
@@ -173,6 +191,11 @@ HttpAccessory.prototype = {
         cType: types.BRIGHTNESS_CTYPE,
         onUpdate: function(value) {
           that.setBrightness(value);
+        },
+        onRead: function(callback) {
+          that.getBrightness(function(level){
+            callback(level);
+          });
         },
         perms: ["pw","pr","ev"],
         format: "int",

--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -27,6 +27,9 @@ HttpAccessory.prototype = {
   },
 
   setPowerState: function(powerOn) {
+    if (!this.on_url) { return; }
+    if (!this.off_url) { return; }
+
     var url;
 
     if (powerOn) {
@@ -49,6 +52,8 @@ HttpAccessory.prototype = {
   },
 
   setBrightness: function(level) {
+    if (!this.brightness_url) { return; }
+
     var url = this.brightness_url.replace("%b", level)
 
     this.log("Setting brightness on the '"+this.name+"' to " + level);

--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -37,26 +37,28 @@ HttpAccessory.prototype = {
       this.log("Setting power state on the '"+this.name+"' to off");
     }
 
+    that = this
+
     this.httpRequest(url, this.http_method, function(error, response, body){
       if (error) {
-        return console.error('http power function failed:', error);
+        that.log('http power function failed:', error);
       }else{
-        return console.log('http power function succeeded!');
+        that.log('http power function succeeded!');
       }
     });
-
   },
 
   setBrightness: function(level) {
     var url = this.brightness_url.replace("%b", level)
 
     this.log("Setting brightness on the '"+this.name+"' to " + level);
+    that = this
 
     this.httpRequest(url, this.http_method, function(error, response, body){
       if (error) {
-        return console.error('http brightness function failed:', error);
+        that.log('http brightness function failed:', error);
       }else{
-        return console.log('http brightness function succeeded!');
+        that.log('http brightness function succeeded!');
       }
     });
 

--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -131,7 +131,9 @@ HttpAccessory.prototype = {
         designedMaxLength: 255
       },{
         cType: types.POWER_STATE_CTYPE,
-        onUpdate: function(value) { that.setPowerState(value); },
+        onUpdate: function(value) {
+          that.setPowerState(value);
+        },
         perms: ["pw","pr","ev"],
         format: "bool",
         initialValue: 0,
@@ -141,7 +143,9 @@ HttpAccessory.prototype = {
         designedMaxLength: 1
       },{
         cType: types.BRIGHTNESS_CTYPE,
-        onUpdate: function(value) { that.setBrightness(value); },
+        onUpdate: function(value) {
+          that.setBrightness(value);
+        },
         perms: ["pw","pr","ev"],
         format: "int",
         initialValue:  0,

--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -26,6 +26,22 @@ HttpAccessory.prototype = {
     })
   },
 
+  getPowerState: function(callback){
+    if (!this.read_powered_url) { callback(null); }
+
+    var that = this;
+    this.log("checking power state for: " + this.name);
+
+    this.httpRequest(this.read_powered_url, 'GET', function(error, response, body){
+      if (error) {
+        that.log('http get powerState failed:', error);
+        callback(null)
+      }else{
+        that.log('http getPowerState function succeeded!');
+        callback(body)
+      }
+    });
+  },
   setPowerState: function(powerOn) {
     if (!this.on_url) { return; }
     if (!this.off_url) { return; }
@@ -140,6 +156,11 @@ HttpAccessory.prototype = {
         cType: types.POWER_STATE_CTYPE,
         onUpdate: function(value) {
           that.setPowerState(value);
+        },
+        onRead: function(callback) {
+          that.getPowerState(function(powerState){
+            callback(powerState);
+          });
         },
         perms: ["pw","pr","ev"],
         format: "bool",

--- a/config-sample.json
+++ b/config-sample.json
@@ -85,6 +85,8 @@
         {
             "accessory": "Http",
             "name": "Kitchen Lamp",
+            "read_powered_url": "https://192.168.1.22:3030/devices/23222/powered",
+            "read_brightness_url": "https://192.168.1.22:3030/devices/23222/brightness",
             "on_url": "https://192.168.1.22:3030/devices/23222/on",
             "off_url": "https://192.168.1.22:3030/devices/23222/off",
             "brightness_url": "https://192.168.1.22:3030/devices/23222/brightness/%b",


### PR DESCRIPTION
This adds the ability to set URLs to read the powered state and brightness state.

This is starting to get a little weird. While the commands (`on`, `off`, `setBrightness`) were easy, because they simply hit a url and thats it...reading is more complicated. This is an abstract implementation, but at the same time, we need to somehow be specific in order to fetch values.

Since we're reading something, we have to decide how we want this to work. Somehow the value has to be read and passed back.

As it is now, all the functions do is return the WHOLE body from the `GET` request. Kinda jank.

## Value Fetching Options
So I think there's 3 options here:

1. Just return the body of the response, and make people understand they have to return a single value in their respones.
2. Specify a key that people need to use in their response (this assumes JSON) that we'll read from.
3. Add a specific read key in the `config.json` that would be used to traverse JSON to fetch a key.

In the first two, it pretty much assumes the user **has** to control the response (hitting their own server they have control over). The third option means they can sort of specify things in a little more detail. But can this be reliable? What happens if the value they need to get to is inside an array or something.

This is all really tricky.

Comments **verrrrrrry** welcome.
