### PR TITLE
Ability to specify a specific MyQDeviceId for the Liftmaster shim

### DIFF
--- a/accessories/LiftMaster.js
+++ b/accessories/LiftMaster.js
@@ -83,19 +83,60 @@ LiftMasterAccessory.prototype = {
         // parse and interpret the response
         var json = JSON.parse(body);
         var devices = json["Devices"];
+        var foundDoors = [];
 
         // look through the array of devices for an opener
         for (var i=0; i<devices.length; i++) {
           var device = devices[i];
-          if ((device["MyQDeviceTypeName"] == "GarageDoorOpener") && ((that.requiredDeviceId == undefined) || (that.requiredDeviceId == device.MyQDeviceId))) {
-            that.deviceId = device.MyQDeviceId;
-            break;
+
+          if (device["MyQDeviceTypeName"] == "GarageDoorOpener") {
+
+            // If we haven't explicity specified a door ID, we'll loop to make sure we don't have multiple openers, which is confusing
+            if (that.requiredDeviceId == undefined) {
+              var thisDeviceId = device.MyQDeviceId;
+              var thisDoorName = "Unknown";
+              for (var j = 0; j < device.Attributes.length; j ++) {
+                var thisAttributeSet = device.Attributes[j];
+                if (thisAttributeSet.AttributeDisplayName == "desc") {
+                  thisDoorName = thisAttributeSet.Value;
+                  break;
+                }
+              }
+              foundDoors.push(thisDeviceId + " - " + thisDoorName);
+            }
+
+            // We specified a door ID, sanity check to make sure it's the one we expected
+            else if (that.requiredDeviceId == device.MyQDeviceId) {
+              that.deviceId = device.MyQDeviceId;
+              break;
+            }
+
           }
+
         }
 
+        // If we have multiple found doors, refuse to proceed
+        if (foundDoors.length > 1) {
+          that.log("WARNING: You have multiple doors on your MyQ account.");
+          that.log("WARNING: Specify the ID of the door you want to control using the 'requiredDeviceId' property in your config.json file.");
+          that.log("WARNING: You can have multiple liftmaster accessories to cover your multiple doors");
+
+          for (var j = 0; j < foundDoors.length; j++) {
+            that.log("Found Door: " + foundDoors[j]);
+          }
+
+          throw "FATAL: Please specify which specific door this Liftmaster accessory should control - you have multiples on your account";
+
+        }
+
+        // Did we get a device ID?
         if (that.deviceId) {
           that.log("Found an opener with ID " + that.deviceId +". Ready to send command...");
           that.setTargetState();
+        }
+        else
+        {
+          that.log("Error: Couldn't find a door device, or the ID you specified isn't associated with your account");
         }
       }
       else {

--- a/accessories/LiftMaster.js
+++ b/accessories/LiftMaster.js
@@ -9,6 +9,7 @@ function LiftMasterAccessory(log, config) {
   this.name = config["name"];
   this.username = config["username"];
   this.password = config["password"];
+  this.requiredDeviceId = config["requiredDeviceId"];
 }
 
 LiftMasterAccessory.prototype = {
@@ -86,14 +87,14 @@ LiftMasterAccessory.prototype = {
         // look through the array of devices for an opener
         for (var i=0; i<devices.length; i++) {
           var device = devices[i];
-          if (device["MyQDeviceTypeName"] == "GarageDoorOpener") {
+          if ((device["MyQDeviceTypeName"] == "GarageDoorOpener") && (that.requiredDeviceId == device.MyQDeviceId)) {
             that.deviceId = device.MyQDeviceId;
             break;
           }
         }
 
         if (that.deviceId) {
-          that.log("Found an opener with ID " + that.deviceId +". Ready to open.");
+          that.log("Found an opener with ID " + that.deviceId +". Ready to send command...");
           that.setTargetState();
         }
       }
@@ -145,6 +146,7 @@ LiftMasterAccessory.prototype = {
           that.log("State was successfully set.");
         else
           that.log("Bad return code: " + json["ReturnCode"]);
+          that.log("Raw response " + JSON.stringify(json));
       }
       else {
         that.log("Error '"+err+"' setting door state: " + JSON.stringify(json));

--- a/accessories/LiftMaster.js
+++ b/accessories/LiftMaster.js
@@ -87,7 +87,7 @@ LiftMasterAccessory.prototype = {
         // look through the array of devices for an opener
         for (var i=0; i<devices.length; i++) {
           var device = devices[i];
-          if ((device["MyQDeviceTypeName"] == "GarageDoorOpener") && (that.requiredDeviceId == device.MyQDeviceId)) {
+          if ((device["MyQDeviceTypeName"] == "GarageDoorOpener") && ((that.requiredDeviceId == undefined) || (that.requiredDeviceId == device.MyQDeviceId))) {
             that.deviceId = device.MyQDeviceId;
             break;
           }

--- a/config-sample.json
+++ b/config-sample.json
@@ -48,6 +48,7 @@
             "accessory": "LiftMaster",
             "name": "Garage Door",
             "description": "This shim supports LiftMaster garage door openers that are already internet-connected to the 'MyQ' service.",
+            // "requiredDeviceId", "<ID of door if you have multiple doors, prompted by shim during startup if needed>",
             "username": "your-liftmaster-username",
             "password" : "your-liftmaster-password"
         },


### PR DESCRIPTION
The existing Liftmaster shim works well if you have a single door opener on an account. If, however, you have multiple doors - it'll operate the first door found on the account.

By (optionally) specifying the device ID in config.json, you can restrict the control to a specific door on the target account.