### PR TITLE
Removed submodule for HAP-NodeJS and moved to NPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/HAP-NodeJS"]
-	path = lib/HAP-NodeJS
-	url = https://github.com/KhaosT/HAP-NodeJS.git

--- a/README.md
+++ b/README.md
@@ -53,17 +53,13 @@ Additionally, the shims I've created implement the bare minimum of HomeKit neede
 
 # Getting Started
 
-OK, if you're still excited enough about ordering Siri to make your coffee (which, who wouldn't be!) then here's how to set things up. First, clone this repo and also init submodules to grab the [HAP-NodeJS](https://github.com/KhaosT/HAP-NodeJS) project which isn't in npm. You'll also need to run `npm install` on HAP-NodeJS:
+OK, if you're still excited enough about ordering Siri to make your coffee (which, who wouldn't be!) then here's how to set things up. First, clone this repo:
 
     $ git clone https://github.com/nfarina/homebridge.git
     $ cd homebridge
-    $ git submodule init
-    $ git submodule update
-    $ npm install
-    $ cd lib/HAP-NodeJS
     $ npm install
 
-**Node**: You'll need to have NodeJS version 0.12.x or better installed for `HAP-NodeJS` to load.
+**Node**: You'll need to have NodeJS version 0.12.x or better installed for required submodule `HAP-NodeJS` to load.
 
 Now you should be able to run the homebridge server:
 

--- a/accessories/AD2USB.js
+++ b/accessories/AD2USB.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var AD2USB = require('ad2usb');
 var CUSTOM_PANEL_LCD_TEXT_CTYPE = "A3E7B8F9-216E-42C1-A21C-97D4E3BE52C8";
 

--- a/accessories/Carwings.js
+++ b/accessories/Carwings.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var carwings = require("carwingsjs");
 
 function CarwingsAccessory(log, config) {

--- a/accessories/ELKM1.js
+++ b/accessories/ELKM1.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var elkington = require("elkington");
 
 function ElkM1Accessory(log, config) {

--- a/accessories/HomeMatic.js
+++ b/accessories/HomeMatic.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function HomeMatic(log, config) {

--- a/accessories/Http.js
+++ b/accessories/Http.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function HttpAccessory(log, config) {

--- a/accessories/LiftMaster.js
+++ b/accessories/LiftMaster.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 // This seems to be the "id" of the official LiftMaster iOS app

--- a/accessories/Lockitron.js
+++ b/accessories/Lockitron.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function LockitronAccessory(log, config) {

--- a/accessories/Sonos.js
+++ b/accessories/Sonos.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var sonos = require('sonos');
 
 function SonosAccessory(log, config) {

--- a/accessories/WeMo.js
+++ b/accessories/WeMo.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var wemo = require('wemo');
 
 // extend our search timeout from 5 seconds to 60

--- a/accessories/X10.js
+++ b/accessories/X10.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function X10(log, config) {

--- a/accessories/XfinityHome.js
+++ b/accessories/XfinityHome.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 var xmldoc = require("xmldoc");
 

--- a/app.js
+++ b/app.js
@@ -101,10 +101,10 @@ function loadPlatforms() {
 //
 
 // Pull in required HAP-NodeJS stuff
-var accessory_Factor = new require("./lib/HAP-NodeJS/Accessory.js");
-var accessoryController_Factor = new require("./lib/HAP-NodeJS/AccessoryController.js");
-var service_Factor = new require("./lib/HAP-NodeJS/Service.js");
-var characteristic_Factor = new require("./lib/HAP-NodeJS/Characteristic.js");
+var accessory_Factor = new require("HAP-NodeJS/Accessory.js");
+var accessoryController_Factor = new require("HAP-NodeJS/AccessoryController.js");
+var service_Factor = new require("HAP-NodeJS/Service.js");
+var characteristic_Factor = new require("HAP-NodeJS/Characteristic.js");
 
 // Each accessory has its own little server. We'll need to allocate some ports for these servers
 var nextPort = 51826;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "git://github.com/nfarina/homebridge.git"
   },
   "dependencies": {
+    "hap-nodejs": "git+https://github.com/khaost/HAP-NodeJS",
     "ad2usb": "git+https://github.com/alistairg/node-ad2usb.git#local",
     "request": "2.49.x",
     "node-persist": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "type": "git",
     "url": "git://github.com/nfarina/homebridge.git"
   },
+  "license": "ISC",
   "dependencies": {
-    "hap-nodejs": "git+https://github.com/khaost/HAP-NodeJS",
+    "hap-nodejs": "git+https://github.com/khaost/HAP-NodeJS#ff5d9f11deae7daf599723d8e2f350553a10645c",
     "ad2usb": "git+https://github.com/alistairg/node-ad2usb.git#local",
     "request": "2.49.x",
     "node-persist": "0.0.x",

--- a/platforms/Domoticz.js
+++ b/platforms/Domoticz.js
@@ -25,7 +25,7 @@
 // When you attempt to add a device, it will ask for a "PIN code".
 // The default code for all HomeBridge accessories is 031-45-154.
 //
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function DomoticzPlatform(log, config){

--- a/platforms/ISY.js
+++ b/platforms/ISY.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var xml2js = require('xml2js');
 var request = require('request');
 var util = require('util');

--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -33,7 +33,7 @@ var hue = require("node-hue-api"),
     HueApi = hue.HueApi,
     lightState = hue.lightState;
 
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 
 function PhilipsHuePlatform(log, config) {
   this.log = log;

--- a/platforms/SmartThings.js
+++ b/platforms/SmartThings.js
@@ -1,7 +1,7 @@
 // SmartThings JSON API SmartApp required
 // https://github.com/jnewland/SmartThings/blob/master/JSON.groovy
 //
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var request = require("request");
 
 function SmartThingsPlatform(log, config){

--- a/platforms/Wink.js
+++ b/platforms/Wink.js
@@ -1,4 +1,4 @@
-var types = require("../lib/HAP-NodeJS/accessories/types.js");
+var types = require("HAP-NodeJS/accessories/types.js");
 var wink = require('wink-js');
 
 var model = {


### PR DESCRIPTION
It seemed to be easier all around to use NPM to manage the dependancy on HAP-NodeJS.

This PR removes the submodule, and adjusts the paths of all checked in shims to reference the NPM module instead.

I also updated the documentation to reflect the simpler install ;)

[Edit by @nfarina: Closes #51]