### PR TITLE
Adding support for iOS9 "transport category"

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ function loadAccessories() {
         var services = accessory.getServices();
 
         // Create the HAP server for this accessory
-        createHAPServer(name, services);
+        createHAPServer(name, services, accessory.transportCategory);
     }
 }
 
@@ -89,7 +89,7 @@ function loadPlatforms() {
                 // hooks in and out of HomeKit for the HAP-NodeJS server.
                 var services = accessory.getServices();
                 // Create the HAP server for this accessory
-                createHAPServer(accessory.name, services);
+                createHAPServer(accessory.name, services, accessory.transportCategory);
             }
             accessories.push.apply(accessories, foundAccessories);
         })
@@ -113,7 +113,7 @@ var accessoryServers = [];
 var accessoryControllers = [];
 var usernames = {};
 
-function createHAPServer(name, services) {
+function createHAPServer(name, services, transportCategory) {
     var accessoryController = new accessoryController_Factor.AccessoryController();
 
     //loop through services
@@ -163,7 +163,7 @@ function createHAPServer(name, services) {
     // hardcode the PIN to something random (same PIN as HAP-NodeJS sample accessories)
     var pincode = "031-45-154";
 
-    var accessory = new accessory_Factor.Accessory(name, username, storage, parseInt(nextPort), pincode, accessoryController);
+    var accessory = new accessory_Factor.Accessory(name, username, storage, parseInt(nextPort), pincode, accessoryController, transportCategory);
     accessoryServers[nextServer] = accessory;
     accessoryControllers[nextServer] = accessoryController;
     accessory.publishAccessory();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "hap-nodejs": "git+https://github.com/khaost/HAP-NodeJS#ff5d9f11deae7daf599723d8e2f350553a10645c",
+    "hap-nodejs": "git+https://github.com/khaost/HAP-NodeJS#2a1bc8d99a2009317ab5da93faebea34c89f197c",
     "ad2usb": "git+https://github.com/alistairg/node-ad2usb.git#local",
     "request": "2.49.x",
     "node-persist": "0.0.x",


### PR DESCRIPTION
- Accessories can specify a "this.transportCategory" constant from the HAP-NodeJS types.js. 
- iOS9 sees this transport type which Siri may well use to help understand the accessory type
- Defaults to iOS8 behavior ("Other" transport type) if none is specified

Updated NPM reference to HAP-NodeJS to include latest revision with these constants and underlying transport support