### PR TITLE
Add support for getting the state of the power to WeMo accessories.

### DIFF
--- a/accessories/WeMo.js
+++ b/accessories/WeMo.js
@@ -54,6 +54,28 @@ WeMoAccessory.prototype = {
     });
   },
 
+  getPowerState: function(callback) {
+
+    if (!this.device) {
+      this.log("No '"+this.wemoName+"' device found (yet?)");
+      return;
+    }
+
+    var that = this;
+
+    this.log("checking power state for: " + this.wemoName);
+    this.device.getBinaryState(function(err, result) {
+        if (!err) {
+            var binaryState = parseInt(result)
+            that.log("power state for " + that.wemoName + " is: " + binaryState)
+            callback(binaryState)
+        }
+        else {
+            that.log(err)
+        }
+    });
+  },
+
   getServices: function() {
     var that = this;
     return [{
@@ -124,6 +146,11 @@ WeMoAccessory.prototype = {
       },{
         cType: types.POWER_STATE_CTYPE,
         onUpdate: function(value) { that.setPowerState(value); },
+        onRead: function(callback) {
+          that.getPowerState(function(powerState){
+            callback(powerState);
+          });
+        },
         perms: ["pw","pr","ev"],
         format: "bool",
         initialValue: false,


### PR DESCRIPTION
Hopefully I haven't done anything too terrible here. I'm not too familiar with JavaScript or Node but it's definitely working for me. The only thing that doesn't seem to work and I think it's been discussed before is that if I manually turn the power on the WeMo device (like using the WeMo app or physically turning it on) I'll have to kill whatever app I'm using and/or wait for it to repoll the state to reflect the changes.