### PR TITLE
Add support for Nest platform.

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -3,6 +3,12 @@
 
     "platforms": [
         {
+            "platform" : "Nest",
+            "name" : "Nest",
+            "username" : "username",
+            "password" : "password"
+        },
+        {
             "platform" : "TelldusLive",
             "name" : "Telldus Live!",
             "public_key" : "telldus public key",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "wink-js": "0.0.5",
     "elkington": "kevinohara80/elkington",
     "node-milight-promise": "0.0.2",
-    "telldus-live" : "0.2.x"
+    "telldus-live" : "0.2.x",
+    "unofficial-nest-api": "0.1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "request": "2.49.x",
     "sonos": "0.8.x",
     "telldus-live": "0.2.x",
-    "unofficial-nest-api": "0.1.x",
+    "unofficial-nest-api": "git+https://github.com/hachidorii/unofficial_nodejs_nest.git#d8d48edc952b049ff6320ef99afa7b2f04cdee98",
     "wemo": "0.2.x",
     "wink-js": "0.0.5",
     "xml2js": "0.4.x",

--- a/platforms/Nest.js
+++ b/platforms/Nest.js
@@ -25,12 +25,12 @@ NestPlatform.prototype = {
                 nest.fetchStatus(function (data) {
                     for (var deviceId in data.device) {
                         if (data.device.hasOwnProperty(deviceId)) {
-                            device = data.device[deviceId];
+                            var device = data.device[deviceId];
                             // it's a thermostat, adjust this to detect other accessories
                             if (data.shared[deviceId].hasOwnProperty('current_temperature'))
                             {
-                                name = data.shared[deviceId].name
-                                accessory = new NestThermostatAccessory(that.log, name, device, deviceId);
+                                var name = data.shared[deviceId].name
+                                var accessory = new NestThermostatAccessory(that.log, name, device, deviceId);
                                 foundAccessories.push(accessory);
                             }
                         }
@@ -58,9 +58,9 @@ NestThermostatAccessory.prototype = {
 
         this.log("Checking current heating cooling for: " + this.name);
         nest.fetchStatus(function (data) {
-            device = data.device[that.deviceId];
+            var device = data.device[that.deviceId];
             
-            currentHeatingCooling = 0;
+            var currentHeatingCooling = 0;
             switch(device.current_schedule_mode) {
                 case "OFF":
                     targetHeatingCooling = 0;
@@ -90,9 +90,9 @@ NestThermostatAccessory.prototype = {
 
         this.log("Checking target heating cooling for: " + this.name);
         nest.fetchStatus(function (data) {
-            device = data.device[that.deviceId];
+            var device = data.device[that.deviceId];
             
-            targetHeatingCooling = 0;
+            var targetHeatingCooling = 0;
             switch(device.target_temperature_type) {
                 case "off":
                     targetHeatingCooling = 0;
@@ -119,7 +119,7 @@ NestThermostatAccessory.prototype = {
         var that = this;
 
         nest.fetchStatus(function (data) {
-            device = data.shared[that.deviceId];
+            var device = data.shared[that.deviceId];
             that.log("Current temperature for " + this.name + " is: " + device.current_temperature);
             callback(device.current_temperature);
         });
@@ -132,7 +132,7 @@ NestThermostatAccessory.prototype = {
         var that = this;
 
         nest.fetchStatus(function (data) {
-            device = data.shared[that.deviceId];
+            var device = data.shared[that.deviceId];
             that.log("Target temperature for " + this.name + " is: " + device.target_temperature);
             callback(device.target_temperature);
         });
@@ -145,8 +145,8 @@ NestThermostatAccessory.prototype = {
         var that = this;
 
         nest.fetchStatus(function (data) {
-            device = data.device[that.deviceId];
-            temperatureUnits = 0;
+            var device = data.device[that.deviceId];
+            var temperatureUnits = 0;
             switch(device.temperature_scale) {
                 case "F":
                     that.log("Tempature unit for " + this.name + " is: " + "Fahrenheit");
@@ -171,7 +171,7 @@ NestThermostatAccessory.prototype = {
         var that = this;
 
         nest.fetchStatus(function (data) {
-            device = data.device[that.deviceId];
+            var device = data.device[that.deviceId];
             that.log("Humidity for " + this.name + " is: " + device.current_humidity);
             callback(device.current_humidity);
         })
@@ -183,7 +183,7 @@ NestThermostatAccessory.prototype = {
 
         var that = this;
 
-        targetTemperatureType = 'off';
+        var targetTemperatureType = 'off';
         switch(targetHeatingCooling) {
             case 0:
                 // this will crash unnofficial-node-api, it needs to be forked to accept the input

--- a/platforms/Nest.js
+++ b/platforms/Nest.js
@@ -186,7 +186,6 @@ NestThermostatAccessory.prototype = {
         var targetTemperatureType = 'off';
         switch(targetHeatingCooling) {
             case 0:
-                // this will crash unnofficial-node-api, it needs to be forked to accept the input
                 targetTemperatureType = 'off';
                 break;
             case 1:

--- a/platforms/Nest.js
+++ b/platforms/Nest.js
@@ -1,0 +1,321 @@
+var types = require("HAP-NodeJS/accessories/types.js");
+var nest = require('unofficial-nest-api');
+
+function NestPlatform(log, config){
+  // auth info
+  this.username = config["username"];
+  this.password = config["password"];
+
+  this.log = log;
+}
+
+NestPlatform.prototype = {
+    accessories: function(callback) {
+        this.log("Fetching Nest devices.");
+
+        var that = this;
+        var foundAccessories = [];
+
+        nest.login(this.username, this.password, function (err, data) {
+            if (err) {
+                that.log("There was a problem authenticating with Nest.");
+            }
+            else {
+                nest.fetchStatus(function (data) {
+                    for (var deviceId in data.device) {
+                        if (data.device.hasOwnProperty(deviceId)) {
+                            device = data.device[deviceId];
+                            // it's a thermostat, adjust this to detect other accessories
+                            if (data.shared[deviceId].hasOwnProperty('current_temperature'))
+                            {
+                                name = data.shared[deviceId].name
+                                accessory = new NestThermostatAccessory(that.log, name, device, deviceId);
+                                foundAccessories.push(accessory);
+                            }
+                        }
+                    }
+                    callback(foundAccessories)
+                });
+            }
+        });
+    }
+}
+
+function NestThermostatAccessory(log, name, device, deviceId) {
+  // device info
+  this.name = name;
+  this.model = device.model_version;
+  this.serial = device.serial_number;
+  this.deviceId = deviceId;
+  this.log = log;
+}
+
+NestThermostatAccessory.prototype = {
+    getCurrentHeatingCooling: function(callback){
+
+        var that = this;
+
+        this.log("Checking current heating cooling for: " + this.name);
+        nest.fetchStatus(function (data) {
+            device = data.device[that.deviceId];
+            that.log("Current healing cooling for " + that.name + " is: " + device.current_schedule_mode)
+            currentHeatingCooling = 0;
+            switch(device.current_schedule_mode) {
+                case "HEAT":
+                    currentHeatingCooling = 1;
+                    break;
+                // this is a guess, I don't have AC to test out the response
+                case "COOL":
+                    currentHeatingCooling = 2;
+                    break;
+                default:
+                    currentHeatingCooling = 0;
+            }
+            callback(currentHeatingCooling);
+        });
+
+
+    },
+
+    getCurrentTemperature: function(callback){
+
+        var that = this;
+
+        nest.fetchStatus(function (data) {
+            device = data.shared[that.deviceId];
+            that.log("Current temperature for " + this.name + " is: " + device.current_temperature);
+            callback(device.current_temperature);
+        });
+
+
+    },
+
+    getTargetTemperature: function(callback){
+
+        var that = this;
+
+        nest.fetchStatus(function (data) {
+            device = data.shared[that.deviceId];
+            that.log("Target temperature for " + this.name + " is: " + device.target_temperature);
+            callback(device.target_temperature);
+        });
+
+
+    },
+
+    getTemperatureUnits: function(callback){
+
+        var that = this;
+
+        nest.fetchStatus(function (data) {
+            device = data.device[that.deviceId];
+            temperatureUnits = 0;
+            switch(device.temperature_scale) {
+                case "F":
+                    that.log("Tempature unit for " + this.name + " is: " + "Fahrenheit");
+                    temperatureUnits = 1;
+                    break;
+                case "C":
+                    that.log("Tempature unit for " + this.name + " is: " + "Celsius");
+                    temperatureUnits = 0;
+                    break;
+                default:
+                    temperatureUnits = 0;
+            }
+
+            callback(temperatureUnits);
+        });
+
+
+    },
+
+    getCurrentRelativeHumidity: function(callback){
+
+        var that = this;
+
+        nest.fetchStatus(function (data) {
+            device = data.device[that.deviceId];
+            that.log("Humidity for " + this.name + " is: " + device.current_humidity);
+            callback(device.current_humidity);
+        })
+
+
+    },
+
+    setTargetTemperature: function(targetTemperature){
+
+        var that = this;
+
+        this.log("Setting target temperature for " + this.name + " to: " + targetTemperature);
+        nest.setTemperature(this.deviceId, targetTemperature);
+
+
+    },
+
+    getServices: function() {
+        var that = this;
+        return [{
+            sType: types.ACCESSORY_INFORMATION_STYPE,
+            characteristics: [{
+                cType: types.NAME_CTYPE,
+                onUpdate: null,
+                perms: ["pr"],
+                format: "string",
+                initialValue: this.name,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Name of the accessory",
+                designedMaxLength: 255
+            },{
+                cType: types.MANUFACTURER_CTYPE,
+                onUpdate: null,
+                perms: ["pr"],
+                format: "string",
+                initialValue: "Nest",
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Manufacturer",
+                designedMaxLength: 255
+            },{
+                cType: types.MODEL_CTYPE,
+                onUpdate: null,
+                perms: ["pr"],
+                format: "string",
+                initialValue: this.model,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Model",
+                designedMaxLength: 255
+            },{
+                cType: types.SERIAL_NUMBER_CTYPE,
+                onUpdate: null,
+                perms: ["pr"],
+                format: "string",
+                initialValue: this.serial,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "SN",
+                designedMaxLength: 255
+            },{
+                cType: types.IDENTIFY_CTYPE,
+                onUpdate: null,
+                perms: ["pw"],
+                format: "bool",
+                initialValue: false,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Identify Accessory",
+                designedMaxLength: 1
+            }]
+        },{
+            sType: types.THERMOSTAT_STYPE, 
+            characteristics: [{
+                cType: types.NAME_CTYPE,
+                onUpdate: null,
+                perms: ["pr"],
+                format: "string",
+                initialValue: this.name,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Name of thermostat",
+                designedMaxLength: 255   
+            },{
+                cType: types.CURRENTHEATINGCOOLING_CTYPE,
+                onUpdate: null,
+                onRead: function(callback) {
+                    that.getCurrentHeatingCooling(function(coolingType){
+                        callback(coolingType);
+                    });
+                },
+                perms: ["pr","ev"],
+                format: "int",
+                initialValue: 0,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Current Mode",
+                designedMaxLength: 1,
+                designedMinValue: 0,
+                designedMaxValue: 2,
+                designedMinStep: 1,    
+            },{
+                cType: types.TARGETHEATINGCOOLING_CTYPE,
+                onUpdate: null,
+                perms: ["pw","pr","ev"],
+                format: "int",
+                initialValue: 0,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Target Mode",
+                designedMinValue: 0,
+                designedMaxValue: 3,
+                designedMinStep: 1,
+            },{
+                cType: types.CURRENT_TEMPERATURE_CTYPE,
+                onUpdate: null,
+                onRead: function(callback) {
+                    that.getCurrentTemperature(function(currentTemperature){
+                        callback(currentTemperature);
+                    });
+                },
+                perms: ["pr","ev"],
+                format: "int",
+                initialValue: 20,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Current Temperature",
+                unit: "celsius"
+            },{
+                cType: types.TARGET_TEMPERATURE_CTYPE,
+                onUpdate: function(value) {
+                    that.setTargetTemperature(value);
+                },
+                onRead: function(callback) {
+                    that.getTargetTemperature(function(targetTemperature){
+                        callback(targetTemperature);
+                    });
+                },
+                perms: ["pw","pr","ev"],
+                format: "int",
+                initialValue: 20,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Target Temperature",
+                designedMinValue: 16,
+                designedMaxValue: 38,
+                designedMinStep: 1,
+                unit: "celsius"
+            },{
+                cType: types.TEMPERATURE_UNITS_CTYPE,
+                onUpdate: null,
+                onRead: function(callback) {
+                    that.getTemperatureUnits(function(temperatureUnits){
+                        callback(temperatureUnits);
+                    });
+                },
+                perms: ["pr","ev"],
+                format: "int",
+                initialValue: 0,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Unit",
+            },{
+                cType: types.CURRENT_RELATIVE_HUMIDITY_CTYPE,
+                onUpdate: null,
+                onRead: function(callback) {
+                    that.getCurrentRelativeHumidity(function(currentRelativeHumidity){
+                        callback(currentRelativeHumidity);
+                    });
+                },
+                perms: ["pr","ev"],
+                format: "int",
+                initialValue: 0,
+                supportEvents: false,
+                supportBonjour: false,
+                manfDescription: "Humidity",
+            }]
+        }];
+    }
+}
+
+module.exports.accessory = NestThermostatAccessory;
+module.exports.platform = NestPlatform;


### PR DESCRIPTION
Most support for Nest is here. Some things I've been unable to test, such as the response for the current_schedule_mode because I do not have AC. The responses seem to mirror the output of the target_temperature_type though and can verify the output there should be correct by the results of others taking a look at the nest api. So with any luck the responses from current_schedule_mode should be correct but I cannot verify it. Other things to note, it doesn't seem like the api provides near current updates and for whatever reason HomeKit's automatic conversion to Fahrenheit seems to be off by a smidgen (.5) when comparing the temperature to what's on the thermostat. The module I was using for nest support had to be forked in order to accept setting the thermostat to off so I forked it and the package in the json points to my fix in a repo of mine. Let me know what you think.

[Edit by @nfarina: Fixes #30]