### PR TITLE
[Philips Hue] retry if command failed due to api rate limit.

### DIFF
--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -216,7 +216,13 @@ PhilipsHueAccessory.prototype = {
         that.log(device.name + ", characteristic: " + characteristic + ", value: " + value + ".");
       }
       else {
-        that.log(err);
+        if (err.code == "ECONNRESET") {
+          setTimeout(function() {
+            that.executeChange(api, device, characteristic, value);
+          }, 300);
+        } else {
+          that.log(err);
+        }
       }
     });
   },


### PR DESCRIPTION
Added a workaround for sending multiple commands to Philips Hue platform.