### PR TITLE
Fix domoticz dimmer handling

### DIFF
--- a/platforms/Domoticz.js
+++ b/platforms/Domoticz.js
@@ -8,6 +8,9 @@
 // - Added support for Scenes
 // - Sorting device names
 //
+// 22 July 2015 [lukeredpath]
+// - Added SSL and basic auth support
+//
 // 26 August 2015 [EddyK69]
 // - Added parameter in config.json: 'loadscenes' for enabling/disabling loading scenes
 // - Fixed issue with dimmer-range; was 0-100, should be 0-16


### PR DESCRIPTION
This pull request should fix the dimming issues mentioned in #128 that meant it wasn't possible to set the dim level to more than 50% of a LightwaveRF (and possibly other devices) using Domoticz.

A previous change (#124) did attempt to fix this problem but was hardcoding the dimmer range to 0-16. The Domoticz documentation isn't very accurate here as LightwaveRF devices (the newest ones anyway) require 0-32 which is why you could never set to more than 50%.

This change uses the MaxDimLevel value that Domoticz supplies instead.