### PR TITLE
File-based motion or contact sensor

### DIFF
--- a/accessories/FileSensor.js
+++ b/accessories/FileSensor.js
@@ -1,0 +1,76 @@
+var Service = require("HAP-NodeJS").Service;
+var Characteristic = require("HAP-NodeJS").Characteristic;
+var chokidar = require("chokidar");
+var debug = require("debug")("FileSensorAccessory");
+var crypto = require("crypto");
+
+module.exports = {
+  accessory: FileSensorAccessory
+}
+
+function FileSensorAccessory(log, config) {
+  this.log = log;
+
+  // url info
+  this.name = config["name"];
+  this.path = config["path"];
+  this.window_seconds = config["window_seconds"] || 5;
+  this.sensor_type = config["sensor_type"] || "m";
+  this.inverse = config["inverse"] || false;
+  
+  if(config["sn"]){
+      this.sn = config["sn"];
+  } else {
+      var shasum = crypto.createHash('sha1');
+      shasum.update(this.path);
+      this.sn = shasum.digest('base64');
+      debug('Computed SN ' + this.sn);
+  }
+}
+
+FileSensorAccessory.prototype = {
+
+  getServices: function() {
+
+    // you can OPTIONALLY create an information service if you wish to override
+    // the default values for things like serial number, model, etc.
+    var informationService = new Service.AccessoryInformation();
+    
+    informationService
+      .setCharacteristic(Characteristic.Name, this.name)
+      .setCharacteristic(Characteristic.Manufacturer, "Homebridge")
+      .setCharacteristic(Characteristic.Model, "File Sensor")
+      .setCharacteristic(Characteristic.SerialNumber, this.sn);
+    
+    var service, changeAction;
+    if(this.sensor_type === "c"){
+        service = new Service.ContactSensor();
+        changeAction = function(newState){
+            service.getCharacteristic(Characteristic.ContactSensorState)
+                    .setValue(newState ? Characteristic.ContactSensorState.CONTACT_DETECTED : Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+        };
+    } else {
+        service = new Service.MotionSensor();
+        changeAction = function(newState){
+            service.getCharacteristic(Characteristic.MotionDetected)
+                    .setValue(newState);
+        };
+    }
+    
+    var changeHandler = function(path, stats){
+        var d = new Date();
+        if(d.getTime() - stats.mtime.getTime() <= (this.window_seconds * 1000)){
+            var newState = this.inverse ? false : true;
+            changeAction(newState);
+            if(this.timer !== undefined) clearTimeout(this.timer);
+            this.timer = setTimeout(function(){changeAction(!newState);}, this.window_seconds * 1000);
+        }
+    }.bind(this);
+    
+    var watcher = chokidar.watch(this.path, {alwaysStat: true});
+    watcher.on('add', changeHandler);
+    watcher.on('change', changeHandler);
+    
+    return [informationService, service];
+  }
+};

--- a/config-sample.json
+++ b/config-sample.json
@@ -196,6 +196,15 @@
             "host" : "localhost",
             "port" : 6600,
             "description": "Allows some control of an MPD server"
+        },
+        {
+            "accessory": "FileSensor",
+            "name": "File Time Motion Sensor",
+            "path": "/tmp/CameraDump/",
+            "window_seconds": 5,
+            "sensor_type": "m",
+            "inverse": false
         }
+
     ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "ad2usb": "git+https://github.com/alistairg/node-ad2usb.git#local",
     "carwingsjs": "0.0.x",
+    "chokidar": "^1.0.5",
     "color": "0.10.x",
     "eibd": "^0.3.1",
     "elkington": "kevinohara80/elkington",


### PR DESCRIPTION
This module creates a motion sensor accessory based on watching a directory or file. This is useful because many inexpensive IP cameras (Foscam, D-Link, others) have an option to FTP an image or video file when they detect motion. If you use this accessory to monitor that FTP drop location, you can expose that camera as a motion sensor to HomeKit.

Config:

* `path`: the dir, file, or glob to watch (see docs for the chokidar module for what's possible)
* `window_seconds`: A file modification date has to be within this many seconds of now to trigger the sensor. This is also the length of time that the sensor will stay triggered before falling back to it's default state.
* `inverse`: if needed, you can invert the behavior of the sensor, for instance so that finding a file means there is ''no'' motion or contact detected.
* `sensor_type`: currently either `"m"` for motion sensor or `"c"` for contact sensor. Contact sensor support is a little wonky right now, it doesn't seem to want to fall back to the untriggered state for some reason--also app support seems to be lacking.