### PR TITLE
Add shim for devices with serial connection

### DIFF
--- a/accessories/GenericRS232Device.js
+++ b/accessories/GenericRS232Device.js
@@ -1,4 +1,5 @@
-var types = require("HAP-NodeJS/accessories/types.js");
+var Service = require("HAP-NodeJS").Service;
+var Characteristic = require("HAP-NodeJS").Characteristic;
 var SerialPort = require("serialport").SerialPort;
 
 module.exports = {
@@ -6,120 +7,51 @@ module.exports = {
 }
 
 function GenericRS232DeviceAccessory(log, config) {
-  this.log = log;
-  this.id = config["id"];
-  this.name = config["name"];
-  this.model_name = config["model_name"];
+  this.log          = log;
+  this.id           = config["id"];
+  this.name         = config["name"];
+  this.model_name   = config["model_name"];
   this.manufacturer = config["manufacturer"];
-  this.on_command = config["on_command"];
-  this.off_command = config["off_command"];
-  this.device = config["device"];
-  this.baudrate = config["baudrate"];
+  this.on_command   = config["on_command"];
+  this.off_command  = config["off_command"];
+  this.device       = config["device"];
+  this.baudrate     = config["baudrate"];
 }
 
 GenericRS232DeviceAccessory.prototype = {
-  getServices: function() {
-    var that = this;
-    return [
-      {
-        sType: types.ACCESSORY_INFORMATION_STYPE,
-        characteristics: [
-          {
-            cType: types.NAME_CTYPE,
-            onUpdate: null,
-            perms: ["pr"],
-            format: "string",
-            initialValue: that.name,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Name of the accessory",
-            designedMaxLength: 255
-          },
-          {
-            cType: types.MANUFACTURER_CTYPE,
-            onUpdate: null,
-            perms: ["pr"],
-            format: "string",
-            initialValue: that.manufacturer,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Manufacturer",
-            designedMaxLength: 255
-          },
-          {
-            cType: types.MODEL_CTYPE,
-            onUpdate: null,
-            perms: ["pr"],
-            format: "string",
-            initialValue: that.model_name,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Model",
-            designedMaxLength: 255
-          },
-          {
-            cType: types.SERIAL_NUMBER_CTYPE,
-            onUpdate: null,
-            perms: ["pr"],
-            format: "string",
-            initialValue: that.id,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "SN",
-            designedMaxLength: 255
-          },
-          {
-            cType: types.IDENTIFY_CTYPE,
-            onUpdate: null,
-            perms: ["pw"],
-            format: "bool",
-            initialValue: false,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Identify Accessory",
-            designedMaxLength: 1
+  setPowerState: function(powerOn, callback) {
+    var that        = this;
+    var command     = powerOn ? that.on_command : that.off_command;
+    var serialPort  = new SerialPort(that.device, { baudrate: that.baudrate }, false);
+    serialPort.open(function (error) {
+      if (error) {
+        callback(new Error('Can not communicate with ' + that.name + " (" + error + ")"))
+      } else {
+        serialPort.write(command, function(err, results) {
+          if (error) {
+            callback(new Error('Can not send power command to ' + that.name + " (" + err + ")"))
+          } else {
+            callback()
           }
-        ]
-      },
-      {
-        sType: types.SWITCH_STYPE,
-        characteristics: [
-          {
-            cType: types.NAME_CTYPE,
-            onUpdate: null,
-            perms: ["pr"],
-            format: "string",
-            initialValue: this.serviceName,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Name of service",
-            designedMaxLength: 255
-          },
-          {
-            cType: types.POWER_STATE_CTYPE,
-            onUpdate: function(value) {
-              var command = (value == 1 ? that.on_command : that.off_command);
-              var serialPort = new SerialPort(that.device, { baudrate: that.baudrate });
-              serialPort.on("open", function () {
-                serialPort.write(command, function(error, results) {
-                  if(error) {
-                    console.log('Errors ' + err);
-                  }
-                });
-              });
-              
-            },
-            perms: ["pw","pr","ev"],
-            format: "bool",
-            initialValue: false,
-            supportEvents: false,
-            supportBonjour: false,
-            manfDescription: "Set the Power state",
-            designedMaxLength: 1
-          }
-        ]
+        });
       }
-    ]
+    });
+  },
+  
+  getServices: function() {
+    var switchService = new Service.Switch();
+    var informationService = new Service.AccessoryInformation();
+
+    informationService
+      .setCharacteristic(Characteristic.Manufacturer, this.manufacturer)
+      .setCharacteristic(Characteristic.Model, this.model_name)
+      .setCharacteristic(Characteristic.SerialNumber, this.id);
+
+    switchService
+      .getCharacteristic(Characteristic.On)
+      .on('set', this.setPowerState.bind(this));
+
+    return [informationService, switchService];
   }
 }
 

--- a/accessories/GenericRS232Device.js
+++ b/accessories/GenericRS232Device.js
@@ -39,7 +39,7 @@ GenericRS232DeviceAccessory.prototype = {
   },
   
   getServices: function() {
-    var switchService = new Service.Switch();
+    var switchService = new Service.Switch(this.name);
     var informationService = new Service.AccessoryInformation();
 
     informationService

--- a/accessories/GenericRS232Device.js
+++ b/accessories/GenericRS232Device.js
@@ -1,0 +1,126 @@
+var types = require("HAP-NodeJS/accessories/types.js");
+var SerialPort = require("serialport").SerialPort;
+
+module.exports = {
+  accessory: GenericRS232DeviceAccessory
+}
+
+function GenericRS232DeviceAccessory(log, config) {
+  this.log = log;
+  this.id = config["id"];
+  this.name = config["name"];
+  this.model_name = config["model_name"];
+  this.manufacturer = config["manufacturer"];
+  this.on_command = config["on_command"];
+  this.off_command = config["off_command"];
+  this.device = config["device"];
+  this.baudrate = config["baudrate"];
+}
+
+GenericRS232DeviceAccessory.prototype = {
+  getServices: function() {
+    var that = this;
+    return [
+      {
+        sType: types.ACCESSORY_INFORMATION_STYPE,
+        characteristics: [
+          {
+            cType: types.NAME_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: that.name,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Name of the accessory",
+            designedMaxLength: 255
+          },
+          {
+            cType: types.MANUFACTURER_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: that.manufacturer,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Manufacturer",
+            designedMaxLength: 255
+          },
+          {
+            cType: types.MODEL_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: that.model_name,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Model",
+            designedMaxLength: 255
+          },
+          {
+            cType: types.SERIAL_NUMBER_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: that.id,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "SN",
+            designedMaxLength: 255
+          },
+          {
+            cType: types.IDENTIFY_CTYPE,
+            onUpdate: null,
+            perms: ["pw"],
+            format: "bool",
+            initialValue: false,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Identify Accessory",
+            designedMaxLength: 1
+          }
+        ]
+      },
+      {
+        sType: types.SWITCH_STYPE,
+        characteristics: [
+          {
+            cType: types.NAME_CTYPE,
+            onUpdate: null,
+            perms: ["pr"],
+            format: "string",
+            initialValue: this.serviceName,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Name of service",
+            designedMaxLength: 255
+          },
+          {
+            cType: types.POWER_STATE_CTYPE,
+            onUpdate: function(value) {
+              var command = (value == 1 ? that.on_command : that.off_command);
+              var serialPort = new SerialPort(that.device, { baudrate: that.baudrate });
+              serialPort.on("open", function () {
+                serialPort.write(command, function(error, results) {
+                  if(error) {
+                    console.log('Errors ' + err);
+                  }
+                });
+              });
+              
+            },
+            perms: ["pw","pr","ev"],
+            format: "bool",
+            initialValue: false,
+            supportEvents: false,
+            supportBonjour: false,
+            manfDescription: "Set the Power state",
+            designedMaxLength: 1
+          }
+        ]
+      }
+    ]
+  }
+}
+
+module.exports.accessory = GenericRS232DeviceAccessory;

--- a/config-sample.json
+++ b/config-sample.json
@@ -205,7 +205,18 @@
             "window_seconds": 5,
             "sensor_type": "m",
             "inverse": false
+        },
+        {
+            "accessory": "GenericRS232Device",
+            "name": "Projector",
+            "description": "Make sure you set a 'Siri-Name' for your iOS-Device (example: 'Home Cinema') otherwise it might not work.",
+            "id": "TYDYMU044UVNP",
+            "baudrate": 9600,
+            "device": "/dev/tty.usbserial",
+            "manufacturer": "Acer",
+            "model_name": "H6510BD",
+            "on_command": "* 0 IR 001\r",
+            "off_command": "* 0 IR 002\r"
         }
-
     ]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "q": "1.4.x",
     "tough-cookie": "^2.0.0",
     "request": "2.49.x",
+    "serialport": "^1.7.4",
     "sonos": "0.8.x",
     "telldus-live": "0.2.x",
     "teslams": "1.0.1",


### PR DESCRIPTION
There are still a lot of devices which are not connected to a network, but can be controlled with a serial connection -- a video projector for example.

I've created a generic accessory shim those devices.
All you need is a serial port or usb-to-serial adapter.

The config values are pretty straight forward.
You set the name, id (a unique string), baud rate, manufacturer, model_name, the two commands for on and off for your device.

Set a Siri-name (e.g. Home Cinema) in your HomeKit app (Eve, Insteon+, ..) and you are good to go.

For example:
```
{
  "accessory": "GenericRS232Device",
  "name": "Projector",
  "id": "TYDYMU044UVNP",
  "baudrate": 9600,
  "device": "/dev/tty.usbserial",
  "manufacturer": "Acer",
  "model_name": "H6510BD",
  "on_command": "* 0 IR 001\r",
  "off_command": "* 0 IR 002\r"
}
```