### PR TITLE
Print scannable setup code to terminal on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,6 +191,16 @@ function createAccessory(accessoryInstance, displayName) {
   }
 }
 
+// Returns the setup code in a scannable format.
+function printPin(pin) {
+  console.log("Scan this code with your HomeKit App on your iOS device:");
+  console.log("\x1b[30;47m%s\x1b[0m", "                       ");
+  console.log("\x1b[30;47m%s\x1b[0m", "    ┌────────────┐     ");
+  console.log("\x1b[30;47m%s\x1b[0m", "    │ " + pin + " │     ");
+  console.log("\x1b[30;47m%s\x1b[0m", "    └────────────┘     ");
+  console.log("\x1b[30;47m%s\x1b[0m", "                       ");
+}
+
 // Returns a logging function that prepends messages with the given name in [brackets].
 function createLog(name) {
   return function(message) {
@@ -210,3 +220,5 @@ function publish() {
 }
 
 startup();
+
+printPin(bridgeConfig.pin);

--- a/app.js
+++ b/app.js
@@ -211,6 +211,7 @@ function createLog(name) {
 }
 
 function publish() {
+  printPin(bridgeConfig.pin);
   bridge.publish({
     username: bridgeConfig.username || "CC:22:3D:E3:CE:30",
     port: bridgeConfig.port || 51826,
@@ -220,5 +221,3 @@ function publish() {
 }
 
 startup();
-
-printPin(bridgeConfig.pin);


### PR DESCRIPTION
This prints the pin code from the config to the terminal in a scannable format.
I was missing this from the first time I've installed homebridge ;)

Here's a example video of what it does:
[![Setup Code](http://img.youtube.com/vi/JYHM4FtCSbw/0.jpg)](http://www.youtube.com/watch?v=JYHM4FtCSbw)
