### PR TITLE
Fix harmony crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "xmldoc": "0.1.x",
     "komponist" : "0.1.0",
     "yamaha-nodejs": "0.4.x",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "node-xmpp-client": "1.0.0-alpha23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eibd": "^0.3.1",
     "elkington": "kevinohara80/elkington",
     "hap-nodejs": "git+https://github.com/KhaosT/HAP-NodeJS#4650e771f356a220868d873d16564a6be6603ff7",
-    "harmonyhubjs-client": "^1.1.4",
+    "harmonyhubjs-client": "enriquez/harmonyhubjs-client#patch-1",
     "harmonyhubjs-discover": "git+https://github.com/swissmanu/harmonyhubjs-discover.git",
     "lifx-api": "^1.0.1",
     "lifx": "git+https://github.com/magicmonkey/lifxjs.git",

--- a/platforms/KNX-sample-config.json
+++ b/platforms/KNX-sample-config.json
@@ -8,7 +8,7 @@
 	"description": "This is an example configuration file for KNX platform shim",
 	"hint": "Always paste into jsonlint.com validation page before starting your homebridge, saves a lot of frustration",
 	"hint2": "Replace all group addresses by current addresses of your installation, these are arbitrary examples!",
-	"hint3": "For valid services and their characteristics have a look at the knxdevice.md file in folder accessories!",
+	"hint3": "For valid services and their characteristics have a look at the KNX.md file in folder platforms!",
 	"platforms": [
 		{
 			"platform": "KNX",

--- a/platforms/KNX-sample-config.json
+++ b/platforms/KNX-sample-config.json
@@ -61,13 +61,13 @@
 					"services": [
 						{
 							"type": "LockMechanism",
-							"description": "iOS8 Lock mechanism, Supports LockCurrentStateSecured0 OR LockCurrentState, LockTargetStateSecured0 OR LockTargetState, use depending if LOCKED is 0 or 1",
+							"description": "iOS8 Lock mechanism, Supports LockCurrentState, LockTargetState, append R to the addresses if LOCKED is 1",
 							"name": "Office Window Lock",
-							"LockCurrentStateSecured0": {
-								"Listen": "5/3/15"
+							"LockCurrentState": {
+								"Listen": "5/3/15R"
 							},
-							"LockTargetStateSecured0": {
-								"Listen": "5/3/15"
+							"LockTargetState": {
+								"Listen": "5/3/16R"
 							}
 						}
 					]

--- a/platforms/KNX.js
+++ b/platforms/KNX.js
@@ -116,8 +116,8 @@ function groupsocketlisten(opts, callback) {
 }
 
 
-var registerSingleGA = function registerSingleGA (groupAddress, callback) {
-	subscriptions.push({address: groupAddress, callback: callback });
+var registerSingleGA = function registerSingleGA (groupAddress, callback, reverse) {
+	subscriptions.push({address: groupAddress, callback: callback, reverse:reverse });
 }
 
 /*
@@ -143,7 +143,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 				if (subscriptions[i].address === dest) {
 					// found one, notify
 					console.log('HIT: Write from '+src+' to '+dest+': '+val+' ['+type+']');
-					subscriptions[i].callback(val, src, dest, type);
+					subscriptions[i].callback(val, src, dest, type, subscriptions[i].reverse);
 				}
 			}
 		});
@@ -156,7 +156,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 				if (subscriptions[i].address === dest) {
 					// found one, notify
 //					console.log('HIT: Response from '+src+' to '+dest+': '+val+' ['+type+']');
-					subscriptions[i].callback(val, src, dest, type);
+					subscriptions[i].callback(val, src, dest, type, subscriptions[i].reverse);
 				}
 			}
 
@@ -185,13 +185,16 @@ var registerGA = function (groupAddresses, callback) {
 	if (groupAddresses.constructor.toString().indexOf("Array") > -1) {
 		// handle multiple addresses
 		for (var i = 0; i < groupAddresses.length; i++) {
-			if (groupAddresses[i]) { // do not bind empty addresses
-				registerSingleGA (groupAddresses[i], callback);
+			if (groupAddresses[i] && groupAddresses[i].match(/(\d*\/\d*\/\d*)/)) { // do not bind empty addresses or invalid addresses
+				// clean the addresses
+				registerSingleGA (groupAddresses[i].match(/(\d*\/\d*\/\d*)/)[0], callback,groupAddresses[i].match(/\d*\/\d*\/\d*(R)/) ? true:false );
 			}
 		}
 	} else {
 		// it's only one
-		registerSingleGA (groupAddresses, callback);
+		if (groupAddresses.match(/(\d*\/\d*\/\d*)/)) {
+			registerSingleGA (groupAddresses.match(/(\d*\/\d*\/\d*)/)[0], callback, groupAddresses[i].match(/\d*\/\d*\/\d*(R)/) ? true:false);
+		}
 	}
 //	console.log("listeners now: " + subscriptions.length);
 };

--- a/platforms/KNX.md
+++ b/platforms/KNX.md
@@ -82,16 +82,16 @@ So the charcteristic section may look like:
             "Listen": [
                 "1/1/63"
             ],
-            minValue: -18,
-            maxValue: 30
+            "minValue": -18,
+            "maxValue": 30
         },
         "TargetTemperature": {
             "Set": "1/1/62",
             "Listen": [
                 "1/1/64"
             ],
-            minValue: -4,
-            maxValue: 12
+            "minValue": -4,
+            "maxValue": 12
         }
     }
 ````
@@ -179,11 +179,11 @@ Likewise, all percentages of DPT5 can be reversed, if you need a 100% (=255) for
  -  On: DPT 1.001, 1 as on, 0 as off
 
 ## TemperatureSensor
--  CurrentTemperature: DPT9.001 in 캜 [listen only]
+-  CurrentTemperature: DPT9.001 in 째C [listen only]
   
 ## Thermostat
--  CurrentTemperature: DPT9.001 in 캜 [listen only], -40 to 80캜 if not overriden as shown above
--  TargetTemperature: DPT9.001, values 0..40캜 only, all others are ignored
+-  CurrentTemperature: DPT9.001 in 째C [listen only], -40 to 80째C if not overriden as shown above
+-  TargetTemperature: DPT9.001, values 0..40째C only, all others are ignored
 -  CurrentHeatingCoolingState: DPT20.102 HVAC, because of the incompatible mapping only off and heating (=auto) are shown, [listen only]
 -  TargetHeatingCoolingState: DPT20.102 HVAC, as above
 

--- a/platforms/KNX.md
+++ b/platforms/KNX.md
@@ -97,11 +97,25 @@ So the charcteristic section may look like:
 ````
 
 
+## reversal of values for characteristics
+In general, all DPT1 types can be reversed. If you need a 1 for "contact" of a contact senser, you can append an "R" to the group address.
+Likewise, all percentages of DPT5 can be reversed, if you need a 100% (=255) for window closed, append an "R" to the group address. Do not forget the listening addresses!
+ ````json
+    {
+        "type": "ContactSensor",
+        "description": "Sample ContactSensor with 1 as contact (0 is Apple's default)",
+        "name": "WindowContact1",
+        "ContactSensorState": {
+            "Listen": [
+                "1/1/100R"
+            ]
+        }
+    }
+````
 # Supported Services and their characteristics
-
 ## ContactSensor
--  ContactSensorState: DPT 1.002, 0 as contact **OR**
--  ContactSensorStateContact1: DPT 1.002, 1 as contact
+-  ContactSensorState: DPT 1.002, 0 as contact 
+-  ~~ContactSensorStateContact1: DPT 1.002, 1 as contact~~
 
 -  StatusActive: DPT 1.011, 1 as true
 -  StatusFault: DPT 1.011, 1 as true
@@ -142,10 +156,10 @@ So the charcteristic section may look like:
 -  CurrentAmbientLightLevel: DPT 9.004, 0 to 100000 Lux 
  
 ## LockMechanism (This is poorly mapped!)
--  LockCurrentState: DPT 1, 1 as secured **OR (but not both:)** 
--  LockCurrentStateSecured0: DPT 1, 0 as secured
--  LockTargetState: DPT 1, 1 as secured **OR**  
--  LockTargetStateSecured0: DPT 1, 0 as secured
+-  LockCurrentState: DPT 1, 1 as secured  
+-  ~~LockCurrentStateSecured0: DPT 1, 0 as secured~~
+-  LockTargetState: DPT 1, 1 as secured 
+-  ~~LockTargetStateSecured0: DPT 1, 0 as secured~~
 
 *ToDo here: correction of mappings, HomeKit reqires lock states UNSECURED=0, SECURED=1, JAMMED = 2, UNKNOWN=3*
 
@@ -181,7 +195,7 @@ So the charcteristic section may look like:
 ## WindowCovering
 -  CurrentPosition: DPT5 percentage
 -  TargetPosition: DPT5 percentage
--  PositionState: DPT5 value [listen only: 0 Closing, 1 Opening, 2 STopped]
+-  PositionState: DPT5 value [listen only: 0 Closing, 1 Opening, 2 Stopped]
 
 ### not yet supported
 -  HoldPosition

--- a/platforms/LogitechHarmony.js
+++ b/platforms/LogitechHarmony.js
@@ -163,9 +163,9 @@ LogitechHarmonyAccessory.prototype = {
     var self = this;
 
     if (this.isActivity) {
-      hub.getCurrentActivity().then(function (currentActivity) {
-        callback(currentActivity.id === self.id);
-      }).except(function (err) {
+      this.hub.getCurrentActivity().then(function (currentActivity) {
+        callback(currentActivity === self.id);
+      }).catch(function (err) {
         self.log('Unable to get current activity with error', err);
         callback(false);
       });
@@ -175,28 +175,23 @@ LogitechHarmonyAccessory.prototype = {
     }
   },
 
-  setPowerState: function (state, callback) {
+  setPowerState: function (state) {
     var self = this;
 
     if (this.isActivity) {
       this.log('Set activity ' + this.name + ' power state to ' + state);
 
-      // Activity id -1 is turn off all devices
-      var id = state ? this.id : -1;
-
-      this.hub.startActivity(id)
+      this.hub.startActivity(self.id)
         .then(function () {
           self.log('Finished setting activity ' + self.name + ' power state to ' + state);
-          callback();
         })
         .catch(function (err) {
           self.log('Failed setting activity ' + self.name + ' power state to ' + state + ' with error ' + err);
-          callback(err);
         });
     } else {
       // TODO: Support setting device power
       this.log('TODO: Support setting device power');
-      callback();
+      // callback();
     }
   },
 
@@ -284,7 +279,9 @@ LogitechHarmonyAccessory.prototype = {
             onUpdate: function (value) {
               self.setPowerState(value)
             },
-            onRead: self.getPowerState,
+            onRead: function(callback) {
+              self.getPowerState(callback)
+            },
             perms: ["pw","pr","ev"],
             format: "bool",
             initialValue: 0,
@@ -300,6 +297,5 @@ LogitechHarmonyAccessory.prototype = {
 
 };
 
-module.exports.accessory = LogitechHarmonyAccessory;
 module.exports.platform = LogitechHarmonyPlatform;
 

--- a/platforms/LogitechHarmony.js
+++ b/platforms/LogitechHarmony.js
@@ -53,6 +53,14 @@ LogitechHarmonyPlatform.prototype = {
         .then(function (client) {
           self.log("Connected to Logitech Harmony remote hub");
 
+          // prevent connection from closing
+          setTimeout(function() {
+            setInterval(function() {
+              self.log("Sending command to prevent timeout");
+              client.getCurrentActivity();
+            }, 20000);
+          }, 5000);
+
           callback(null, client);
         });
     };


### PR DESCRIPTION
The latest version of node-xmpp-client causes a bunch of StringPrep errors. Freezing the version to 1.0.0-alpha23 fixes that.

The crashes on `isActivity` reported in #185 and #198 are fixed by calling the `getPowerState` function directly.

Also, I had to fix a crash in harmonyhubjs-client. I've sent them a pull request here https://github.com/swissmanu/harmonyhubjs-client/pull/13

I was able to get my activities to work, but after a minute or so it stops. It might be related to #215.