### PR TITLE
Update of handling of binary and percentage type KNX values

### DIFF
--- a/platforms/KNX-sample-config.json
+++ b/platforms/KNX-sample-config.json
@@ -8,7 +8,7 @@
 	"description": "This is an example configuration file for KNX platform shim",
 	"hint": "Always paste into jsonlint.com validation page before starting your homebridge, saves a lot of frustration",
 	"hint2": "Replace all group addresses by current addresses of your installation, these are arbitrary examples!",
-	"hint3": "For valid services and their characteristics have a look at the knxdevice.md file in folder accessories!",
+	"hint3": "For valid services and their characteristics have a look at the KNX.md file in folder platforms!",
 	"platforms": [
 		{
 			"platform": "KNX",

--- a/platforms/KNX-sample-config.json
+++ b/platforms/KNX-sample-config.json
@@ -61,13 +61,13 @@
 					"services": [
 						{
 							"type": "LockMechanism",
-							"description": "iOS8 Lock mechanism, Supports LockCurrentStateSecured0 OR LockCurrentState, LockTargetStateSecured0 OR LockTargetState, use depending if LOCKED is 0 or 1",
+							"description": "iOS8 Lock mechanism, Supports LockCurrentState, LockTargetState, append R to the addresses if LOCKED is 1",
 							"name": "Office Window Lock",
-							"LockCurrentStateSecured0": {
-								"Listen": "5/3/15"
+							"LockCurrentState": {
+								"Listen": "5/3/15R"
 							},
-							"LockTargetStateSecured0": {
-								"Listen": "5/3/15"
+							"LockTargetState": {
+								"Listen": "5/3/16R"
 							}
 						}
 					]

--- a/platforms/KNX.js
+++ b/platforms/KNX.js
@@ -116,8 +116,8 @@ function groupsocketlisten(opts, callback) {
 }
 
 
-var registerSingleGA = function registerSingleGA (groupAddress, callback) {
-	subscriptions.push({address: groupAddress, callback: callback });
+var registerSingleGA = function registerSingleGA (groupAddress, callback, reverse) {
+	subscriptions.push({address: groupAddress, callback: callback, reverse:reverse });
 }
 
 /*
@@ -143,7 +143,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 				if (subscriptions[i].address === dest) {
 					// found one, notify
 					console.log('HIT: Write from '+src+' to '+dest+': '+val+' ['+type+']');
-					subscriptions[i].callback(val, src, dest, type);
+					subscriptions[i].callback(val, src, dest, type, subscriptions[i].reverse);
 				}
 			}
 		});
@@ -156,7 +156,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 				if (subscriptions[i].address === dest) {
 					// found one, notify
 //					console.log('HIT: Response from '+src+' to '+dest+': '+val+' ['+type+']');
-					subscriptions[i].callback(val, src, dest, type);
+					subscriptions[i].callback(val, src, dest, type, subscriptions[i].reverse);
 				}
 			}
 
@@ -185,13 +185,16 @@ var registerGA = function (groupAddresses, callback) {
 	if (groupAddresses.constructor.toString().indexOf("Array") > -1) {
 		// handle multiple addresses
 		for (var i = 0; i < groupAddresses.length; i++) {
-			if (groupAddresses[i]) { // do not bind empty addresses
-				registerSingleGA (groupAddresses[i], callback);
+			if (groupAddresses[i] && groupAddresses[i].match(/(\d*\/\d*\/\d*)/)) { // do not bind empty addresses or invalid addresses
+				// clean the addresses
+				registerSingleGA (groupAddresses[i].match(/(\d*\/\d*\/\d*)/)[0], callback,groupAddresses[i].match(/\d*\/\d*\/\d*(R)/) ? true:false );
 			}
 		}
 	} else {
 		// it's only one
-		registerSingleGA (groupAddresses, callback);
+		if (groupAddresses.match(/(\d*\/\d*\/\d*)/)) {
+			registerSingleGA (groupAddresses.match(/(\d*\/\d*\/\d*)/)[0], callback, groupAddresses[i].match(/\d*\/\d*\/\d*(R)/) ? true:false);
+		}
 	}
 //	console.log("listeners now: " + subscriptions.length);
 };

--- a/platforms/KNX.md
+++ b/platforms/KNX.md
@@ -97,11 +97,25 @@ So the charcteristic section may look like:
 ````
 
 
+## reversal of values for characteristics
+In general, all DPT1 types can be reversed. If you need a 1 for "contact" of a contact senser, you can append an "R" to the group address.
+Likewise, all percentages of DPT5 can be reversed, if you need a 100% (=255) for window closed, append an "R" to the group address. Do not forget the listening addresses!
+ ````json
+    {
+        "type": "ContactSensor",
+        "description": "Sample ContactSensor with 1 as contact (0 is Apple's default)",
+        "name": "WindowContact1",
+        "ContactSensorState": {
+            "Listen": [
+                "1/1/100R"
+            ]
+        }
+    }
+````
 # Supported Services and their characteristics
-
 ## ContactSensor
--  ContactSensorState: DPT 1.002, 0 as contact **OR**
--  ContactSensorStateContact1: DPT 1.002, 1 as contact
+-  ContactSensorState: DPT 1.002, 0 as contact 
+-  ~~ContactSensorStateContact1: DPT 1.002, 1 as contact~~
 
 -  StatusActive: DPT 1.011, 1 as true
 -  StatusFault: DPT 1.011, 1 as true
@@ -142,10 +156,10 @@ So the charcteristic section may look like:
 -  CurrentAmbientLightLevel: DPT 9.004, 0 to 100000 Lux 
  
 ## LockMechanism (This is poorly mapped!)
--  LockCurrentState: DPT 1, 1 as secured **OR (but not both:)** 
--  LockCurrentStateSecured0: DPT 1, 0 as secured
--  LockTargetState: DPT 1, 1 as secured **OR**  
--  LockTargetStateSecured0: DPT 1, 0 as secured
+-  LockCurrentState: DPT 1, 1 as secured  
+-  ~~LockCurrentStateSecured0: DPT 1, 0 as secured~~
+-  LockTargetState: DPT 1, 1 as secured 
+-  ~~LockTargetStateSecured0: DPT 1, 0 as secured~~
 
 *ToDo here: correction of mappings, HomeKit reqires lock states UNSECURED=0, SECURED=1, JAMMED = 2, UNKNOWN=3*
 
@@ -181,7 +195,7 @@ So the charcteristic section may look like:
 ## WindowCovering
 -  CurrentPosition: DPT5 percentage
 -  TargetPosition: DPT5 percentage
--  PositionState: DPT5 value [listen only: 0 Closing, 1 Opening, 2 STopped]
+-  PositionState: DPT5 value [listen only: 0 Closing, 1 Opening, 2 Stopped]
 
 ### not yet supported
 -  HoldPosition


### PR DESCRIPTION
The use of 0/1 for binary objects depends on installation, a contact
sensor can have contact=1 or open=1
The same applies to percentages:  a window can be 100% closed or 100%
open.

For a more general usage of reversed values, a suffix ("R") can now be
attached to all DPT1 and DPT5 group addresses.
Please see updated KNX.md for examples and details.

Note: outdated characteristic-workaround throw an exception at boot-up:
-  ContactSensorStateContact1
-  LockCurrentStateSecured0
-  LockTargetStateSecured0
Please see error message and KNX.md for reference.