### PR TITLE
New UUID generation

### DIFF
--- a/accessories/knxdevice.js
+++ b/accessories/knxdevice.js
@@ -17,6 +17,8 @@ New 2015-09-19:
 New 2015-10-02:
 - Check for valid group addresses
 - new "R" flag allowed for Boolean addresses: 1/2/3R is the boolean not(1/2/3), i.e. 0 and 1 switched on read and write
+New 2015-10-07:
+- Accept uuid_base parameter from config.json to use as unique identifier in UUIDs instead of name (optional)
  * 
  */
 var Service = require("HAP-NodeJS").Service;
@@ -37,6 +39,9 @@ function KNXDevice(log, config) {
 	log("Accessory constructor called");
 	if (config.name) {
 		this.name = config.name;
+	}
+	if (config.uuid_base) {
+		this.uuid_base = config.uuid_base;
 	}
 	if (config.knxd_ip){
 		this.knxd_ip = config.knxd_ip;

--- a/app.js
+++ b/app.js
@@ -86,7 +86,7 @@ function loadAccessories() {
         log("Initializing %s accessory...", accessoryType);
         
         var accessoryInstance = new accessoryConstructor(log, accessoryConfig);
-        var accessory = createAccessory(accessoryInstance, accessoryName);
+        var accessory = createAccessory(accessoryInstance, accessoryName, accessoryType, accessoryConfig.uuid_base);  //pass accessoryType for UUID generation, and optional parameter uuid_base which can be used instead of displayName for UUID generation
         
         // add it to the bridge
         bridge.addBridgedAccessory(accessory);
@@ -113,11 +113,11 @@ function loadPlatforms() {
         log("Initializing %s platform...", platformType);
 
         var platformInstance = new platformConstructor(log, platformConfig);
-        loadPlatformAccessories(platformInstance, log);
+        loadPlatformAccessories(platformInstance, log, platformType);
     }
 }
 
-function loadPlatformAccessories(platformInstance, log) {
+function loadPlatformAccessories(platformInstance, log, platformType) {
   asyncCalls++;
   platformInstance.accessories(once(function(foundAccessories){
       asyncCalls--;
@@ -129,7 +129,7 @@ function loadPlatformAccessories(platformInstance, log) {
           
           log("Initializing platform accessory '%s'...", accessoryName);
           
-          var accessory = createAccessory(accessoryInstance, accessoryName);
+          var accessory = createAccessory(accessoryInstance, accessoryName, platformType, accessoryInstance.uuid_base);
 
           // add it to the bridge
           bridge.addBridgedAccessory(accessory);
@@ -141,7 +141,7 @@ function loadPlatformAccessories(platformInstance, log) {
   }));
 }
 
-function createAccessory(accessoryInstance, displayName) {
+function createAccessory(accessoryInstance, displayName, accessoryType, uuid_base) {
   
   var services = accessoryInstance.getServices();
   
@@ -159,7 +159,7 @@ function createAccessory(accessoryInstance, displayName) {
     // The returned "services" for this accessory are simply an array of new-API-style
     // Service instances which we can add to a created HAP-NodeJS Accessory directly.
     
-    var accessoryUUID = uuid.generate(accessoryInstance.constructor.name + ":" + displayName);
+    var accessoryUUID = uuid.generate(accessoryType + ":" + (uuid_base || displayName));
     
     var accessory = new Accessory(displayName, accessoryUUID);
     


### PR DESCRIPTION
addresses #203

# This is a breaking change for all configured homekit databases, as it will remove room/area assignments and other things configured in iOS apps
... unless your accessory type was called `Object` before

Changes:
- Without any changes to the configuration file all accessories UUIDs will be generated by  `uuid.generate(accessoryType + ":"` instead of the constructor name which turned out to be unreliable in that context.  So about all UUIDs will change.
- For platforms the platformType will be used, as configured in config.json at eg. `"platform":"Nest"`
- new parameter uuid_base can be used for accessories in config.json to use a different base for UUID generation than the displayName, which might not be unique
- platforms can add the same property to their accessories before returned, just as they have a name property right now.