### PR TITLE
Simple fix for undefined Nest device names

### DIFF
--- a/platforms/Nest.js
+++ b/platforms/Nest.js
@@ -44,7 +44,11 @@ NestPlatform.prototype = {
 
 function NestThermostatAccessory(log, name, device, deviceId) {
   // device info
-  this.name = name;
+  if (name) {
+    this.name = name;
+  } else {
+    this.name = "Nest";
+  }
   this.model = device.model_version;
   this.serial = device.serial_number;
   this.deviceId = deviceId;


### PR DESCRIPTION
Nest is no longer returning device names in all cases.