### PR TITLE
Fix MyQ Garage Opener and multiple Nests configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,8 @@ npm-debug.log
 
 # HomeBridge
 config.json
+config.test.json
 persist/
+
+
+.AppleDouble

--- a/accessories/LiftMaster.js
+++ b/accessories/LiftMaster.js
@@ -89,7 +89,7 @@ LiftMasterAccessory.prototype = {
         for (var i=0; i<devices.length; i++) {
           var device = devices[i];
 
-          if (device["MyQDeviceTypeName"] == "GarageDoorOpener") {
+          if (device["MyQDeviceTypeName"] == "GarageDoorOpener" || device["MyQDeviceTypeName"] == "VGDO") {
 
             // If we haven't explicity specified a door ID, we'll loop to make sure we don't have multiple openers, which is confusing
             if (!that.requiredDeviceId) {

--- a/platforms/Nest.js
+++ b/platforms/Nest.js
@@ -47,7 +47,7 @@ function NestThermostatAccessory(log, name, device, deviceId) {
   if (name) {
     this.name = name;
   } else {
-    this.name = "Nest";
+    this.name = "Nest" + device.serial_number;
   }
   this.model = device.model_version;
   this.serial = device.serial_number;


### PR DESCRIPTION
This patch checks the MyQDeviceTypeName property against VGDO, which is used by MyQ to identify a "virtual garage door opener".
It also fixes the scenario where multiple Nests are present: the accessory name needs to be unique.