### PR TITLE
Fixed initial color of Philips Hue

### DIFF
--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -167,7 +167,7 @@ PhilipsHueAccessory.prototype = {
   // Convert 0-65535 to 0-360
   hueToArcDegrees: function(value) {
     value = value/65535;
-    value = value*100;
+    value = value*360;
     value = Math.round(value);
     return value;
   },


### PR DESCRIPTION
Fixed initial color calc to range from 0-360 (as documented) instead of 0-100 (likely typo).  Something is still off with the color matching but it is much closer with this.