### PR TITLE
added serialport library as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "wink-js": "0.0.5",
     "xml2js": "0.4.x",
     "xmldoc": "0.1.x",
-    "yamaha-nodejs": "0.4.x"
+    "yamaha-nodejs": "0.4.x",
+    "serialport": "2.0.x"
   }
 }


### PR DESCRIPTION
When trying to use the serial port accessory:

Loading 0 platforms...
Loading 1 accessories...
module.js:338
    throw err;
    ^

Error: Cannot find module 'serialport'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/mifi/Desktop/homebridge/accessories/GenericRS232Device.js:3:18)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)


added serialport library as a dependency