### PR TITLE
Fixed unreachable PhilipsHue bulbs to show up as off.

### DIFF
--- a/platforms/PhilipsHue.js
+++ b/platforms/PhilipsHue.js
@@ -190,7 +190,7 @@ PhilipsHueAccessory.prototype = {
   extractValue: function(characteristic, status) {
     switch(characteristic.toLowerCase()) {
       case 'power':
-        return status.state.on  ? 1 : 0;
+        return status.state.reachable && status.state.on ? 1 : 0;
       case 'hue':
         return this.hueToArcDegrees(status.state.hue);
       case 'brightness':


### PR DESCRIPTION
Fixed unreachable PhilipsHue bulbs to show up as off.  If you have a manual switch hooked up to a hue bulb, turning it off the switch makes it unreachable but doesn't mark it as off.