### PR TITLE
Provide and output proper existing error message

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -176,6 +176,10 @@ Plugin.installed = function() {
         pjson = Plugin.loadPackageJSON(pluginPath);
       }
       catch (err) {
+        if (name.substring(0,11) === 'homebridge-') {
+          // show warning only if module starts with prefix
+          log.warn("Warning: skipping plugin found at '" + pluginPath + "' because of: " + err.message);
+        }
         // swallow error and skip this module
         continue;
       }


### PR DESCRIPTION
If the found plugin / package does not fulfill some specs (i.e. does not contain the keyword `homebridge-plugin`), it will be rejected with an error. Without that change nobody will be notified WHY the plugin has been rejected/skipped.

That is only a proposal, perhaps we can solve the problem in another way. But that specific information forced spending too much time.