### PR TITLE
Add test for valid username

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -27,16 +27,16 @@ function Server() {
 }
 
 Server.prototype.run = function() {
-  
+
   // keep track of async calls we're waiting for callbacks on before we can start up
   this._asyncCalls = 0;
   this._asyncWait = true;
-  
+
   if (this._config.platforms) this._loadPlatforms();
   if (this._config.accessories) this._loadAccessories();
-  
+
   this._asyncWait = false;
-  
+
   // publish now unless we're waiting on anyone
   if (this._asyncCalls == 0)
     this._publish();
@@ -53,18 +53,18 @@ Server.prototype._publish = function() {
     pincode: bridgeConfig.pin || "031-45-154",
     category: Accessory.Categories.OTHER
   });
-  
+
   log.info("Homebridge is running on port %s.", bridgeConfig.port || 51826);
 }
 
 Server.prototype._loadPlugins = function(accessories, platforms) {
-  
+
   var plugins = {};
   var foundOnePlugin = false;
-  
+
   // load and validate plugins - check for valid package.json, etc.
   Plugin.installed().forEach(function(plugin) {
-        
+
     // attempt to load it
     try {
       plugin.load();
@@ -78,7 +78,7 @@ Server.prototype._loadPlugins = function(accessories, platforms) {
     }
 
     if (!plugin.loadError) {
-      
+
       // add it to our dict for easy lookup later
       plugins[plugin.name()] = plugin;
 
@@ -90,19 +90,19 @@ Server.prototype._loadPlugins = function(accessories, platforms) {
       log.info("---");
       foundOnePlugin = true;
     }
-    
+
   }.bind(this));
 
   // Complain if you don't have any plugins.
   if (!foundOnePlugin) {
     log.warn("No plugins found. See the README for information on installing plugins.")
   }
-  
+
   return plugins;
 }
 
 Server.prototype._loadConfig = function() {
-  
+
   // Look for the configuration file
   var configPath = User.configPath();
 
@@ -111,7 +111,7 @@ Server.prototype._loadConfig = function() {
       log.error("Couldn't find a config.json file at '"+configPath+"'. Look at config-sample.json for examples of how to format your config.js and add your home accessories.");
       process.exit(1);
   }
-  
+
   // Load up the configuration file
   var config;
   try {
@@ -123,11 +123,20 @@ Server.prototype._loadConfig = function() {
     log.error("");
     throw err;
   }
-  
+
+  var accessoryCount = (config.accessories && config.accessories.length) || 0;
+
+  var username = config.bridge.username;
+  var validMac = /^([0-9A-F]{2}:){5}([0-9A-F]{2})$/;
+  if (!validMac.test(username)){
+      throw new Error('Not a valid username: ' + username + '. Must be 6 pairs of colon-' +
+                      'separated hexadecimal chars (A-F 0-9), like a MAC address.');
+  }
+
   var accessoryCount = (config.accessories && config.accessories.length) || 0;
   var platformCount = (config.platforms && config.platforms.length) || 0;
   log.info("Loaded config.json with %s accessories and %s platforms.", accessoryCount, platformCount);
-  
+
   log.info("---");
 
   return config;
@@ -145,7 +154,7 @@ Server.prototype._loadAccessories = function() {
 
   // Instantiate all accessories in the config
   log.info("Loading " + this._config.accessories.length + " accessories...");
-  
+
   for (var i=0; i<this._config.accessories.length; i++) {
 
     var accessoryConfig = this._config.accessories[i];
@@ -162,10 +171,10 @@ Server.prototype._loadAccessories = function() {
     var accessoryLogger = Logger.withPrefix(accessoryName);
 
     accessoryLogger("Initializing %s accessory...", accessoryType);
-    
+
     var accessoryInstance = new accessoryConstructor(accessoryLogger, accessoryConfig);
     var accessory = this._createAccessory(accessoryInstance, accessoryName, accessoryType, accessoryConfig.uuid_base);  //pass accessoryType for UUID generation, and optional parameter uuid_base which can be used instead of displayName for UUID generation
-    
+
     // add it to the bridge
     this._bridge.addBridgedAccessory(accessory);
   }
@@ -174,7 +183,7 @@ Server.prototype._loadAccessories = function() {
 Server.prototype._loadPlatforms = function() {
 
     log.info("Loading " + this._config.platforms.length + " platforms...");
-    
+
     for (var i=0; i<this._config.platforms.length; i++) {
 
         var platformConfig = this._config.platforms[i];
@@ -201,20 +210,20 @@ Server.prototype._loadPlatformAccessories = function(platformInstance, log, plat
   this._asyncCalls++;
   platformInstance.accessories(once(function(foundAccessories){
       this._asyncCalls--;
-      
+
       // loop through accessories adding them to the list and registering them
       for (var i = 0; i < foundAccessories.length; i++) {
           var accessoryInstance = foundAccessories[i];
           var accessoryName = accessoryInstance.name; // assume this property was set
-          
+
           log("Initializing platform accessory '%s'...", accessoryName);
-          
+
           var accessory = this._createAccessory(accessoryInstance, accessoryName, platformType, accessoryInstance.uuid_base);
 
           // add it to the bridge
           this._bridge.addBridgedAccessory(accessory);
       }
-      
+
       // were we the last callback?
       if (this._asyncCalls === 0 && !this._asyncWait)
         this._publish();
@@ -222,9 +231,9 @@ Server.prototype._loadPlatformAccessories = function(platformInstance, log, plat
 }
 
 Server.prototype._createAccessory = function(accessoryInstance, displayName, accessoryType, uuid_base) {
-  
+
   var services = accessoryInstance.getServices();
-  
+
   if (!(services[0] instanceof Service)) {
     // The returned "services" for this accessory is assumed to be the old style: a big array
     // of JSON-style objects that will need to be parsed by HAP-NodeJS's AccessoryLoader.
@@ -238,26 +247,26 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
   else {
     // The returned "services" for this accessory are simply an array of new-API-style
     // Service instances which we can add to a created HAP-NodeJS Accessory directly.
-    
+
     var accessoryUUID = uuid.generate(accessoryType + ":" + (uuid_base || displayName));
-    
+
     var accessory = new Accessory(displayName, accessoryUUID);
-    
+
     // listen for the identify event if the accessory instance has defined an identify() method
     if (accessoryInstance.identify)
       accessory.on('identify', function(paired, callback) { accessoryInstance.identify(callback); });
-    
+
     services.forEach(function(service) {
-      
+
       // if you returned an AccessoryInformation service, merge its values with ours
       if (service instanceof Service.AccessoryInformation) {
         var existingService = accessory.getService(Service.AccessoryInformation);
-        
+
         // pull out any values you may have defined
         var manufacturer = service.getCharacteristic(Characteristic.Manufacturer).value;
         var model = service.getCharacteristic(Characteristic.Model).value;
         var serialNumber = service.getCharacteristic(Characteristic.SerialNumber).value;
-        
+
         if (manufacturer) existingService.setCharacteristic(Characteristic.Manufacturer, manufacturer);
         if (model) existingService.setCharacteristic(Characteristic.Model, model);
         if (serialNumber) existingService.setCharacteristic(Characteristic.SerialNumber, serialNumber);
@@ -266,7 +275,7 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
         accessory.addService(service);
       }
     });
-    
+
     return accessory;
   }
 }


### PR DESCRIPTION
Like a MAC address, a valid username can only contain 6 pairs of
hexadecimal characters, and for homebridge purposes must be
colon-separated. This adds a simple regex test for a proper username,
since I just spent nearly 24h trying to debug an issue that all came
down to not realizing that a MAC address could only have letters A-F
(see https://github.com/nfarina/homebridge/issues/385).