### PR TITLE
Update hap-nodejs to 0.1.1

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,7 +51,7 @@ Server.prototype._publish = function() {
     username: bridgeConfig.username || "CC:22:3D:E3:CE:30",
     port: bridgeConfig.port || 51826,
     pincode: bridgeConfig.pin || "031-45-154",
-    category: Accessory.Categories.OTHER
+    category: Accessory.Categories.BRIDGE
   });
 
   log.info("Homebridge is running on port %s.", bridgeConfig.port || 51826);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.0.7",
+    "hap-nodejs": "0.1.1",
     "semver": "5.0.3"
   }
 }


### PR DESCRIPTION
Update homebridge's hap-nodejs dependency to version 0.1.1
This should solve the accessory disappear problem for some users (as now characteristic can actually provide a meaningful default value.)
Update homebridge's accessory category to type "Bridge" which addressed #478.