### PR TITLE
new getServiceByUUIDAndSubtype(UUID, subtype) function

### DIFF
--- a/lib/platformAccessory.js
+++ b/lib/platformAccessory.js
@@ -60,6 +60,12 @@ PlatformAccessory.prototype.addService = function(service) {
   return service;
 }
 
+/**
+ * searchs for a Service in the services collection and returns the first Service object that matches.
+ * If multiple services of the same type are present in one accessory, use getServiceByUUIDAndSubType instead.
+ * @param {ServiceConstructor|string} name
+ * @returns Service
+ */
 PlatformAccessory.prototype.getService = function(name) {
   for (var index in this.services) {
     var service = this.services[index];
@@ -70,6 +76,25 @@ PlatformAccessory.prototype.getService = function(name) {
       return service;
   }
 }
+
+/**
+ * searchs for a Service in the services collection and returns the first Service object that matches.
+ * If multiple services of the same type are present in one accessory, use getServiceByUUIDAndSubType instead.
+ * @param {string} UUID Can be an UUID, a service.displayName, or a constructor of a Service
+ * @param {string} subtype A subtype string to match
+ * @returns Service
+ */
+PlatformAccessory.prototype.getServiceByUUIDAndSubType = function(UUID, subtype) {
+  for (var index in this.services) {
+    var service = this.services[index];
+    
+    if (typeof UUID === 'string' && (service.displayName === UUID || service.name === UUID) && service.subtype === subtype )
+      return service;
+    else if (typeof name === 'function' && ((service instanceof name) || (name.UUID === service.UUID)) && service.subtype === subtype)
+      return service;
+  }
+}
+
 
 PlatformAccessory.prototype.updateReachability = function(reachable) {
   this.reachable = reachable;


### PR DESCRIPTION
Some platforms may have accessories that contain more than one service of a given type, such as multiple lightbulbs.