### PR TITLE
Handle SIGINT and SIGTERM to enable clean shutdown of Homebridge

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,5 +23,17 @@ module.exports = function() {
   // Initialize HAP-NodeJS with a custom persist directory
   hap.init(User.persistPath());
   
-  new Server(insecureAccess).run();
+  var server = new Server(insecureAccess);
+
+  var signals = { 'SIGINT': 2, 'SIGTERM': 15 };
+  Object.keys(signals).forEach(function (signal) {
+    process.on(signal, function () {
+      log.info("Got %s, shutting down Homebridge...", signal);
+
+      // FIXME: Shut down server cleanly
+      process.exit(128 + signals[signal]);
+    });
+  });
+
+  server.run();
 }


### PR DESCRIPTION
For now we terminate the process, but in the future we may tell the
server to stop, which may possibly include some teardown logic.

Handling these signals also make it easier to put Homebridge inside
a docker container, as docker uses SIGTERM to tell a container process
to stop, and passes SIGINT when attached to the container and receiving
a Ctrl+C.