### PR TITLE
Ref #582

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can also chat with us in our nascent [Slack instance](http://homebridge-slac
 
 Homebridge is published through [NPM](https://www.npmjs.com/package/homebridge) and should be installed "globally" by typing:
 
-    sudo npm install -g homebridge
+    sudo npm install -g --unsafe-perm homebridge
 
 Now you should be able to run Homebridge:
 


### PR DESCRIPTION
Ref#582 Add ‘--unsafe-perm’ flag to npm install command to get round all the .gyp warns etc.