### PR TITLE
Add note about --unsafe-perm

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Homebridge is published through [NPM](https://www.npmjs.com/package/homebridge) 
 
     sudo npm install -g homebridge
 
+You may need to use the `--unsafe-perm` flag if you receive an error similar to this:
+
+    gyp WARN EACCES user "root" does not have permission to access the dev dir "/root/.node-gyp/5.5.0"
+
 Now you should be able to run Homebridge:
 
     $ homebridge


### PR DESCRIPTION
I received the following error when trying to install homebridge on a RaspberryPi. Assuming I'm not the first or the last to see this error, I thought adding a note to README about the --unsafe-perm flag would aid others.