### PR TITLE
Replace existing accessory info service with custom

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -390,22 +390,38 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
 
     services.forEach(function(service) {
 
-      // if you returned an AccessoryInformation service, merge its values with ours
+      // if you returned an AccessoryInformation service, merge in default values
       if (service instanceof Service.AccessoryInformation) {
         var existingService = accessory.getService(Service.AccessoryInformation);
 
         // pull out any values you may have defined
+        var name = service.getCharacteristic(Characteristic.Name).value;
         var manufacturer = service.getCharacteristic(Characteristic.Manufacturer).value;
         var model = service.getCharacteristic(Characteristic.Model).value;
         var serialNumber = service.getCharacteristic(Characteristic.SerialNumber).value;
 
-        if (manufacturer) existingService.setCharacteristic(Characteristic.Manufacturer, manufacturer);
-        if (model) existingService.setCharacteristic(Characteristic.Model, model);
-        if (serialNumber) existingService.setCharacteristic(Characteristic.SerialNumber, serialNumber);
+        // pull out existing default values
+        var existingName = existingService.getCharacteristic(Characteristic.Name).value;
+        var existingManufacturer = existingService.getCharacteristic(Characteristic.Manufacturer).value;
+        var existingModel = existingService.getCharacteristic(Characteristic.Model).value;
+        var existingSerialNumber = existingService.getCharacteristic(Characteristic.SerialNumber).value;
+
+        if (!name) service.setCharacteristic(Characteristic.Name, existingName);
+        if (!manufacturer) service.setCharacteristic(Characteristic.Manufacturer, existingManufacturer);
+        if (!model) service.setCharacteristic(Characteristic.Model, existingModel);
+        if (!serialNumber) service.setCharacteristic(Characteristic.SerialNumber, existingSerialNumber);
+
+        // copy identify listeners
+        var identify = service.getCharacteristic(Characteristic.Identify);
+        var existingIdentify = existingService.getCharacteristic(Characteristic.Identify);
+        existingIdentify.listeners('set').forEach(function(listener) {
+          existingIdentify.removeListener('set', listener);
+          identify.on('set', listener);
+        });
+
+        accessory.removeService(service);
       }
-      else {
-        accessory.addService(service);
-      }
+      accessory.addService(service);
     });
 
     return accessory;


### PR DESCRIPTION
HAP creates a default InformationService for each accessory that's created. If a homebridge plugin returns an InformationService for an accessory, the existing service is updated with the values from the custom service, but the plugin accessory has no way to access the existing service. This PR _replaces_ the existing service with the custom service, defaulting any missing values to the values found in the existing service. It also copies over the "paired identify" event listener that HAP creates on the existing service (and any other listeners). This allows plugin authors to retain access to the information service for later manipulation.
