### PR TITLE
Use hap-nodejs 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true"
   },
@@ -26,7 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.3.2",
+    "hap-nodejs": "0.4.0",
     "semver": "5.0.3",
     "node-persist": "^0.0.8"
   }


### PR DESCRIPTION
This bumps the version of HAP to `0.4.0` so that Homebridge has the new IP camera support.

This is a super naive pull and hasn't  been fully tested. There may be other incompatibilities not taken into consideration, but it looks like `0.4.0` was just additions.

/cc @KhaosT 

I also only bumped Homebridge's version to `0.3.5` since nothing should actually break here.