### PR TITLE
Fix camera name in collision error message

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -473,7 +473,7 @@ Server.prototype._handlePublishCameraAccessories = function(accessories) {
     var advertiseAddress = mac.generate(accessory.UUID);
 
     if (this._publishedCameras[advertiseAddress]) {
-      throw new Error("Camera accessory %s experienced an address collision.", accessory.displayName);
+      throw new Error("Camera accessory " + accessory.displayName + " experienced an address collision.");
     } else {
       this._publishedCameras[advertiseAddress] = accessory;
     }


### PR DESCRIPTION
If a camera address collides, the error message includes a literal "%s":

```javascript
/usr/lib/node_modules/homebridge/lib/server.js:476
      throw new Error("Camera accessory %s experienced an address collision.", accessory.displayName);
      ^

Error: Camera accessory %s experienced an address collision.
```

The `Error` constructor doesn't support format strings: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error 

This PR changes the error message to use string concatenation, correcting the name:

```
Error: Camera accessory Camera1 experienced an address collision.
```
