### PR TITLE
Use chalk instead of hardcoded ANSI codes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ var BridgeSetupManager = require("./bridgeSetupManager").BridgeSetupManager;
 var log = require("./logger")._system;
 var Logger = require('./logger').Logger;
 var mac = require("./util/mac");
+var chalk = require('chalk');
 
 'use strict';
 
@@ -578,9 +579,9 @@ Server.prototype._handleNewConfig = function(type, name, replace, config) {
 // Returns the setup code in a scannable format.
 Server.prototype._printPin = function(pin) {
   console.log("Scan this code with your HomeKit App on your iOS device to pair with Homebridge:");
-  console.log("\x1b[30;47m%s\x1b[0m", "                       ");
-  console.log("\x1b[30;47m%s\x1b[0m", "    ┌────────────┐     ");
-  console.log("\x1b[30;47m%s\x1b[0m", "    │ " + pin + " │     ");
-  console.log("\x1b[30;47m%s\x1b[0m", "    └────────────┘     ");
-  console.log("\x1b[30;47m%s\x1b[0m", "                       ");
+  console.log(chalk.black.bgWhite("                       "));
+  console.log(chalk.black.bgWhite("    ┌────────────┐     "));
+  console.log(chalk.black.bgWhite("    │ " + pin + " │     "));
+  console.log(chalk.black.bgWhite("    └────────────┘     "));
+  console.log(chalk.black.bgWhite("                       "));
 }


### PR DESCRIPTION
Improves the readability of the source code and prevents the raw ANSI codes from appearing in the log, if ran as a systemd service.