### PR TITLE
Allow externally specified config

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,9 @@ module.exports = {
   Server: Server
 }
 
-function Server(insecureAccess) {
+function Server(insecureAccess, opts) {
+  opts = opts || {};
+
   // Setup Accessory Cache Storage
   accessoryStorage.initSync({ dir: User.cachedAccessoryPath() });
 
@@ -46,7 +48,7 @@ function Server(insecureAccess) {
   }.bind(this));
 
   this._plugins = this._loadPlugins(); // plugins[name] = Plugin instance
-  this._config = this._loadConfig();  
+  this._config = opts.config || this._loadConfig();
   this._cachedPlatformAccessories = this._loadCachedPlatformAccessories();
   this._bridge = this._createBridge();
 
@@ -55,7 +57,7 @@ function Server(insecureAccess) {
   this._publishedCameras = {};
   this._setupManager = new BridgeSetupManager();
   this._setupManager.on('newConfig', this._handleNewConfig.bind(this));
-  
+
   this._setupManager.on('requestCurrentConfig', function(callback) {
     callback(this._config);
   }.bind(this));
@@ -93,7 +95,7 @@ Server.prototype.run = function() {
 Server.prototype._publish = function() {
   // pull out our custom Bridge settings from config.json, if any
   var bridgeConfig = this._config.bridge || {};
-  
+
   var info = this._bridge.getService(Service.AccessoryInformation);
   if (bridgeConfig.manufacturer)
     info.setCharacteristic(Characteristic.Manufacturer, bridgeConfig.manufacturer);
@@ -168,7 +170,7 @@ Server.prototype._loadConfig = function() {
   // Complain and exit if it doesn't exist yet
   if (!fs.existsSync(configPath)) {
     log.warn("config.json (%s) not found.", configPath);
-    
+
     var config = {};
 
     config.bridge = {
@@ -427,7 +429,7 @@ Server.prototype._handleRegisterPlatformAccessories = function(accessories) {
 
     accessory._prepareAssociatedHAPAccessory();
     hapAccessories.push(accessory._associatedHAPAccessory);
-    
+
     this._cachedPlatformAccessories.push(accessory);
   }
 
@@ -513,7 +515,7 @@ Server.prototype._handleNewConfig = function(type, name, replace, config) {
     } else {
       var targetName;
       if (name.indexOf('.') !== -1) {
-        targetName = name.split(".")[1];  
+        targetName = name.split(".")[1];
       }
       var found = false;
       for (var index in this._config.accessories) {
@@ -545,7 +547,7 @@ Server.prototype._handleNewConfig = function(type, name, replace, config) {
     } else {
       var targetName;
       if (name.indexOf('.') !== -1) {
-        targetName = name.split(".")[1];  
+        targetName = name.split(".")[1];
       }
 
       var found = false;


### PR DESCRIPTION
I'm using this module with [confit](https://github.com/krakenjs/confit) which will allow me to split my (relatively complex) config files up, generate some dynamic configs, etc. This simple change allows me to bypass loading config.json cleanly.