### PR TITLE
Added serverVersion to API; bumped API version to 2.2

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -21,7 +21,7 @@ function API() {
   this._dynamicPlatforms = {}; // this._dynamicPlatforms[pluginName.platformName] = platform constructor
   
   // expose the homebridge API version
-  this.version = "2.1.1";
+  this.version = 2.2;
 
   // expose the homebridge server version
   this.serverVersion = serverVersion;

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ var hapLegacyTypes = require("hap-nodejs/accessories/types.js");
 var log = require("./logger")._system;
 var User = require("./user").User;
 var PlatformAccessory = require("./platformAccessory").PlatformAccessory;
+var serverVersion = require("./version");
 
 // The official homebridge API is the object we feed the plugin's exported initializer function.
 
@@ -20,7 +21,10 @@ function API() {
   this._dynamicPlatforms = {}; // this._dynamicPlatforms[pluginName.platformName] = platform constructor
   
   // expose the homebridge API version
-  this.version = 2.1;
+  this.version = "2.1.1";
+
+  // expose the homebridge server version
+  this.serverVersion = serverVersion;
 
   // expose the User class methods to plugins to get paths. Example: homebridge.user.storagePath()
   this.user = User;


### PR DESCRIPTION
I'm extending https://github.com/gismo141/homebridge-server and would like to show the version of homebridge there by using the homebridge API.