### PR TITLE
Add an entry point for Typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "http://github.com/nfarina/homebridge/issues"
   },
   "license": "ISC",
+  "main": "lib/api.js",
   "bin": {
     "homebridge": "bin/homebridge"
   },


### PR DESCRIPTION
This small change would make it possible to create Typescript typings for the API class, which would make writing plugins in Typescript cleaner.