### PR TITLE
Version bump to 0.4.25 wit HAP-NodeJS 0.4.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true"
   },
@@ -26,7 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.4.29",
+    "hap-nodejs": "0.4.30",
     "semver": "5.0.3",
     "node-persist": "^0.0.8"
   }


### PR DESCRIPTION
New HAP-NodeJS version should resolve the issue with a device showing as "Not Supported" and issues from Apple removing Optional characteristics.