### PR TITLE
Version bump to 0.4.26 and HAP-NodeJS 0.4.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true"
   },
@@ -26,7 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.4.30",
+    "hap-nodejs": "0.4.31",
     "semver": "5.0.3",
     "node-persist": "^0.0.8"
   }


### PR DESCRIPTION
This version cleans up a number of issues with backwards compatibility and refines the characteristic validation process.