### PR TITLE
Attempt to fix not-responding accessories issue introduced with iOS11

### DIFF
--- a/lib/bridgeSetupSession.js
+++ b/lib/bridgeSetupSession.js
@@ -182,7 +182,7 @@ BridgeSetupSession.prototype.sendResponse = function(response) {
     this.lastResponse = respData;
     setTimeout(function() {
       this.controlChar.setValue(respData);
-    }.bind(this), 100);
+    }.bind(this), 10);
   }
 }
 


### PR DESCRIPTION
Hi,

this is an attempt to fix "not-responding" issue with iOS11. 
Basically, after the upgrade of my iPhone to iOS11, I see that sometimes the devices are seen as "not-responding" in the iPhone Home App.

The issue has been reported in many places, e.g.:
nfarina/homebridge#1514
nfarina/homebridge#1414
nfarina/homebridge#1350
nfarina/homebridge#1501

I'm not an expert of Node.js, but could it simply be that the new iOS 11 requires a more tight response time?
For this reason I've reduced the timeout to send the response to 10ms instead of 100ms.
I've tried the fix on my Raspberry PI and for now it seems to be working.
Any input on this?
I'd just like to help you guys fixing this nasty bug.

Thanks in advance