### PR TITLE
Check plugin's engines.node version

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -56,6 +56,13 @@ Plugin.prototype.load = function(options) {
     throw new Error("Plugin " + this.pluginPath + " requires a HomeBridge version of " + versionRequired + " which does not satisfy the current HomeBridge version of " + version + ". You may need to upgrade your installation of HomeBridge.");
   }
 
+  var nodeVersionRequired = pjson.engines.node;
+
+  // make sure the version is satisfied by the currently running version of Node
+  if (nodeVersionRequired && !semver.satisfies(process.version, nodeVersionRequired)) {
+    throw new Error("Plugin " + this.pluginPath + " requires Node version of " + nodeVersionRequired + " which does not satisfy the current Node version of " + process.version + ". You may need to upgrade your installation of Node.");
+  }
+
   // figure out the main module - index.js unless otherwise specified
   var main = pjson.main || "./index.js";
 


### PR DESCRIPTION
I'm currently doing this in [homebridge-hs100](https://github.com/plasticrake/homebridge-hs100/blob/6ffac57083865e55145b3821ec37d6b0023bf734/lib/platform.js#L39) and I got the idea from [ebaauw/homebridge-hue](https://github.com/ebaauw/homebridge-hue/blob/b74732615bdeae08c8e2c729375ffbe80d09eec7/lib/HuePlatform.js#L511). Instead of each plugin checking the node version have Homebridge do it same as it checks `engines.homebridge` already. The check only runs if `engines.node` is specified in the package.json. If node is missing the check won't happen (so it won't break any plugins that do not specify a node version)