### PR TITLE
Check plugin's engines.node version and warn if not met

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -56,6 +56,13 @@ Plugin.prototype.load = function(options) {
     throw new Error("Plugin " + this.pluginPath + " requires a HomeBridge version of " + versionRequired + " which does not satisfy the current HomeBridge version of " + version + ". You may need to upgrade your installation of HomeBridge.");
   }
 
+  var nodeVersionRequired = pjson.engines.node;
+
+  // make sure the version is satisfied by the currently running version of Node
+  if (nodeVersionRequired && !semver.satisfies(process.version, nodeVersionRequired)) {
+    log.warn("Plugin " + this.pluginPath + " requires Node version of " + nodeVersionRequired + " which does not satisfy the current Node version of " + process.version + ". You may need to upgrade your installation of Node.");
+  }
+
   // figure out the main module - index.js unless otherwise specified
   var main = pjson.main || "./index.js";
 


### PR DESCRIPTION
Same as last time, but only warn so won't cause issues with plugins