### PR TITLE
Use crossplatform `os.homedir()` instead of env vars

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var os = require('os');
 
 'use strict';
 
@@ -19,15 +20,14 @@ var customStoragePath;
 
 function User() {
 }
-  
+
 User.config = function() {
   return config || (config = Config.load(User.configPath()));
 }
-  
+
 User.storagePath = function() {
   if (customStoragePath) return customStoragePath;
-  var home = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-  return path.join(home, ".homebridge");
+  return path.join(os.homedir(), ".homebridge");
 }
 
 User.configPath = function() {


### PR DESCRIPTION
Maybe fix #1551?