### PR TITLE
Populate accessory information for Homebridge from NPM package

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -3,12 +3,7 @@
         "name": "Homebridge",
         "username": "CC:22:3D:E3:CE:30",
         "port": 51826,
-        "pin": "031-45-154",
-        "manufacturer": "@nfarina",
-        "model": "Homebridge",
-        "serialNumber": "Not Specified",
-        "firmwareRevision": "0.4.27",
-        "hardwareRevision": "<optional>"
+        "pin": "031-45-154"
     },
     
     "description": "This is an example configuration file with one fake accessory and one fake platform. You can use this as a template for creating your own configuration file containing devices you actually own.",

--- a/lib/server.js
+++ b/lib/server.js
@@ -104,7 +104,7 @@ Server.prototype._publish = function() {
   var info = this._bridge.getService(Service.AccessoryInformation);
   info.setCharacteristic(Characteristic.Manufacturer, `${toTitleCase(require('../package.json').author.name)}`);
   info.setCharacteristic(Characteristic.Model, `${toTitleCase(require('../package.json').name)}`);
-  info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.pin);
+  info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.username);
   info.setCharacteristic(Characteristic.FirmwareRevision, require('../package.json').version);
 
   this._printPin(bridgeConfig.pin);

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,6 +24,10 @@ module.exports = {
   Server: Server
 }
 
+function toTitleCase(str) {
+  return str.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+}
+
 function Server(insecureAccess, opts) {
   opts = opts || {};
 
@@ -98,16 +102,10 @@ Server.prototype._publish = function() {
   var bridgeConfig = this._config.bridge || {};
 
   var info = this._bridge.getService(Service.AccessoryInformation);
-  if (bridgeConfig.manufacturer)
-    info.setCharacteristic(Characteristic.Manufacturer, bridgeConfig.manufacturer);
-  if (bridgeConfig.model)
-    info.setCharacteristic(Characteristic.Model, bridgeConfig.model);
-  if (bridgeConfig.serialNumber)
-    info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.serialNumber);
-  if (bridgeConfig.firmwareRevision)
-    info.setCharacteristic(Characteristic.FirmwareRevision, bridgeConfig.firmwareRevision);
-  if (bridgeConfig.hardwareRevision)
-    info.setCharacteristic(Characteristic.HardwareRevision, bridgeConfig.hardwareRevision);
+  info.setCharacteristic(Characteristic.Manufacturer, `${toTitleCase(require('../package.json').author.name)}`);
+  info.setCharacteristic(Characteristic.Model, `${toTitleCase(require('../package.json').name)}`);
+  info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.pin);
+  info.setCharacteristic(Characteristic.FirmwareRevision, require('../package.json').version);
 
   this._printPin(bridgeConfig.pin);
 


### PR DESCRIPTION
- Populate accessory information from `package.json`
- Remove need for user to manually specify