### PR TITLE
Use proper accessory name in debug log if more than one accessory.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -487,9 +487,12 @@ Server.prototype._handlePublishCameraAccessories = function(accessories) {
       this._publishedCameras[advertiseAddress] = accessory;
     }
 
-    hapAccessory.on('listening', function(port) {
-      log.info("%s is running on port %s.", accessory.displayName, port);
-    });
+    (function(name){
+      hapAccessory.on('listening', function(port) {
+  
+          log.info("%s is running on port %s.", name, port);
+      })
+    })(accessory.displayName);
 
     hapAccessory.publish({
       username: advertiseAddress,


### PR DESCRIPTION
Minor issue but was annoying while debugging a plugin with multiple cameras. Only the last camera name was listed in the the CLI output.