### PR TITLE
Probot Stale - Auto close old stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 14
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity, and will be closed if no further activity occurs. If this
+  issue was overlooked, forgotten, or should remain open for any other reason,
+  please reply here to call attention to it and remove the stale status. Thank
+  you for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
The bulk of the open issues are over a year old. I assume either the people who submitted the issues either no longer have the issue, or have moved on.

With this configuration, the bot will mark them as stale if they have 6 months of no activity, and after 2 weeks of being marked stale with no activity, close the issue. Those 2 weeks will give anyone watching the issue the ability to comment on the issue and reset the 6 months if the issue is still valid.

Issues with the `pinned` label are whitelisted and will never be marked as stale. More labels can be added to the whitelist if appropriate.

@nfarina As the repo owner, If you'd like to use this you'll need to add this: https://probot.github.io/apps/stale/