### PR TITLE
Expose the information service

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -433,6 +433,10 @@ Server.prototype._createAccessory = function(accessoryInstance, displayName, acc
       }
     });
 
+    // expose the information service, this will allow deferred update of characteristics
+    if (accessoryInstance.setInformationService)
+      accessoryInstance.setInformationService(accessory.getService(Service.AccessoryInformation));
+      
     return accessory;
   }
 }


### PR DESCRIPTION
Expose the information service, this will allow deferred update of characteristics for a standalone accessory that has no platform.

Currently there is no way to deferred update the characteristics of the automatically generated Information Service. Information such as firmware revision and serial number are often retrieved by asynchronous request from an accessory device and should be set when available.