### PR TITLE
fix: Accessory is name newAccessory

### DIFF
--- a/example-plugins/homebridge-samplePlatform/index.js
+++ b/example-plugins/homebridge-samplePlatform/index.js
@@ -183,7 +183,7 @@ SamplePlatform.prototype.addAccessory = function(accessoryName) {
 
   var newAccessory = new Accessory(accessoryName, uuid);
   newAccessory.on('identify', function(paired, callback) {
-    platform.log(accessory.displayName, "Identify!!!");
+    platform.log(newAccessory.displayName, "Identify!!!");
     callback();
   });
   // Plugin can save context on accessory to help restore accessory in configureAccessory()
@@ -193,7 +193,7 @@ SamplePlatform.prototype.addAccessory = function(accessoryName) {
   newAccessory.addService(Service.Lightbulb, "Test Light")
   .getCharacteristic(Characteristic.On)
   .on('set', function(value, callback) {
-    platform.log(accessory.displayName, "Light -> " + value);
+    platform.log(newAccessory.displayName, "Light -> " + value);
     callback();
   });
 


### PR DESCRIPTION
Example crashes with:
/home/pi/homebridge-xxx/index.js:196
    platform.log(accessory.displayName, "Light -> " + value);

ReferenceError: accessory is not defined

----------
Thanks for providing Homebridge!