### PR TITLE
Prevent npm update check warnings/errors

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -127,7 +127,7 @@ Plugin.getDefaultPaths = function() {
       paths.push('/usr/local/lib/node_modules');
       paths.push('/usr/lib/node_modules');
       const exec = require('child_process').execSync;
-      paths.push(exec('/bin/echo -n "$(npm -g prefix)/lib/node_modules"').toString('utf8'));
+      paths.push(exec('/bin/echo -n "$(npm --no-update-notifier -g prefix)/lib/node_modules"').toString('utf8'));
     }
   }
   return paths;


### PR DESCRIPTION
When running homebridge as an unprivileged user this warning may be displayed when homebridge executes `npm -g prefix` at startup.

```
┌───────────────────────────────────────────────────┐
│              npm update check failed              │
│        Try running with sudo or get access        │
│       to the local update config store via        │
│ sudo chown -R $USER:$(id -gn $USER) /root/.config │
└───────────────────────────────────────────────────┘
```

This PR prevents npm doing it's update check when homebridge starts.

Older versions of npm that don't have this "feature" will ignore the flag silently.