### PR TITLE
Selective load

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -140,7 +140,7 @@ Server.prototype._loadPlugins = function(accessories, platforms) {
   Plugin.installed().forEach(function(plugin) {
 
     if (this._selectiveLoad === true && activePlugins[plugin.name()] !== true) {
-      continue;
+      return;
     }
 
     // attempt to load it
@@ -549,10 +549,11 @@ Server.prototype._updateCachedAccessories = function() {
 }
 
 Server.prototype._teardown = function() {
-  this._updateCachedAccessories();
-  this._bridge.unpublish();
-  Object.keys(this._publishedCameras).forEach(function (advertiseAddress) {
-    this._publishedCameras[advertiseAddress]._associatedHAPAccessory.unpublish();
+  var self = this;
+  self._updateCachedAccessories();
+  self._bridge.unpublish();
+  Object.keys(self._publishedCameras).forEach(function (advertiseAddress) {
+    self._publishedCameras[advertiseAddress]._associatedHAPAccessory.unpublish();
   });
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -253,6 +253,7 @@ Server.prototype._computeActivePluginList = function() {
 
   if (this._config.accessories) {
     for (var i=0; i<this._config.accessories.length; i++) {
+      var accessoryConfig = this._config.accessories[i];
       var accessoryType = accessoryConfig["accessory"];
       var separatorIndex = accessoryType.indexOf(".");
       if (separatorIndex !== -1) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -254,6 +254,10 @@ Server.prototype._computeActivePluginList = function() {
   if (this._config.accessories) {
     for (var i=0; i<this._config.accessories.length; i++) {
       var accessoryType = accessoryConfig["accessory"];
+      var separatorIndex = accessoryType.indexOf(".");
+      if (separatorIndex !== -1) {
+        accessoryType = accessoryType.substr(0, separatorIndex);
+      }
       activePlugins[accessoryType] = true;
     }
   }
@@ -262,6 +266,10 @@ Server.prototype._computeActivePluginList = function() {
     for (var i=0; i<this._config.platforms.length; i++) {
       var platformConfig = this._config.platforms[i];
       var platformType = platformConfig["platform"];
+      var separatorIndex = platformType.indexOf(".");
+      if (separatorIndex !== -1) {
+        platformType = platformType.substr(0, separatorIndex);
+      }
       activePlugins[platformType] = true;
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -53,8 +53,9 @@ function Server(insecureAccess, opts) {
     this._handlePublishCameraAccessories(accessories);
   }.bind(this));
 
-  this._plugins = this._loadPlugins(); // plugins[name] = Plugin instance
   this._config = opts.config || this._loadConfig();
+  this._selectiveLoad = this._config.selectiveLoad || false;
+  this._plugins = this._loadPlugins(); // plugins[name] = Plugin instance
   this._cachedPlatformAccessories = this._loadCachedPlatformAccessories();
   this._bridge = this._createBridge();
 
@@ -133,9 +134,14 @@ Server.prototype._loadPlugins = function(accessories, platforms) {
 
   var plugins = {};
   var foundOnePlugin = false;
+  var activePlugins = this._computeActivePluginList();
 
   // load and validate plugins - check for valid package.json, etc.
   Plugin.installed().forEach(function(plugin) {
+
+    if (this._selectiveLoad === true && activePlugins[plugin.name()] !== true) {
+      continue;
+    }
 
     // attempt to load it
     try {
@@ -240,6 +246,27 @@ Server.prototype._loadCachedPlatformAccessories = function() {
   }
 
   return platformAccessories;
+}
+
+Server.prototype._computeActivePluginList = function() {
+  var activePlugins = {};
+
+  if (this._config.accessories) {
+    for (var i=0; i<this._config.accessories.length; i++) {
+      var accessoryType = accessoryConfig["accessory"];
+      activePlugins[accessoryType] = true;
+    }
+  }
+
+  if (this._config.platforms) {
+    for (var i=0; i<this._config.platforms.length; i++) {
+      var platformConfig = this._config.platforms[i];
+      var platformType = platformConfig["platform"];
+      activePlugins[platformType] = true;
+    }
+  }
+
+  return activePlugins;
 }
 
 Server.prototype._createBridge = function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,7 +54,6 @@ function Server(insecureAccess, opts) {
   }.bind(this));
 
   this._config = opts.config || this._loadConfig();
-  this._selectiveLoad = this._config.selectiveLoad || false;
   this._plugins = this._loadPlugins(); // plugins[name] = Plugin instance
   this._cachedPlatformAccessories = this._loadCachedPlatformAccessories();
   this._bridge = this._createBridge();
@@ -139,7 +138,7 @@ Server.prototype._loadPlugins = function(accessories, platforms) {
   // load and validate plugins - check for valid package.json, etc.
   Plugin.installed().forEach(function(plugin) {
 
-    if (this._selectiveLoad === true && activePlugins[plugin.name()] !== true) {
+    if (activePlugins !== undefined && activePlugins[plugin.name()] !== true) {
       return;
     }
 
@@ -249,30 +248,15 @@ Server.prototype._loadCachedPlatformAccessories = function() {
 }
 
 Server.prototype._computeActivePluginList = function() {
-  var activePlugins = {};
-
-  if (this._config.accessories) {
-    for (var i=0; i<this._config.accessories.length; i++) {
-      var accessoryConfig = this._config.accessories[i];
-      var accessoryType = accessoryConfig["accessory"];
-      var separatorIndex = accessoryType.indexOf(".");
-      if (separatorIndex !== -1) {
-        accessoryType = accessoryType.substr(0, separatorIndex);
-      }
-      activePlugins[accessoryType] = true;
-    }
+  if (this._config.plugins === undefined) {
+    return undefined;
   }
 
-  if (this._config.platforms) {
-    for (var i=0; i<this._config.platforms.length; i++) {
-      var platformConfig = this._config.platforms[i];
-      var platformType = platformConfig["platform"];
-      var separatorIndex = platformType.indexOf(".");
-      if (separatorIndex !== -1) {
-        platformType = platformType.substr(0, separatorIndex);
-      }
-      activePlugins[platformType] = true;
-    }
+  var activePlugins = {};
+  
+  for (var i=0; i<this._config.plugins.length; i++) {
+    var pluginName = this._config.plugins[i];
+    activePlugins[pluginName] = true;
   }
 
   return activePlugins;


### PR DESCRIPTION
Enhancement to https://github.com/nfarina/homebridge/pull/1866.

Instead of using launch argument, this PR implemented the feature as a configurable parameter in `config.json`.

Since this happens before the plugin given the chance to load the short name, user needs to update their configuration to use full plugin name in order for plugin to load if `selectiveLoad` key is there.

Example:
```json
{
    "bridge": {
        "name": "Homebridge",
        "username": "AA:BB:CC:DD:EE:FF",
        "pin": "010-11-101"
    },
    "selectiveLoad": true,
    "accessories": [],
    "platforms": []
}
```

@ebaauw @Nastras @theo-69 @SeydX thoughts?