### PR TITLE
Logger enhancements.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,12 +17,14 @@ module.exports = function() {
     .option('-P, --plugin-path [path]', 'look for plugins installed at [path] as well as the default locations ([path] can also point to a single plugin)', function(p) { Plugin.addPluginPath(p); })
     .option('-U, --user-storage-path [path]', 'look for homebridge user files at [path] instead of the default location (~/.homebridge)', function(p) { User.setStoragePath(p); })
     .option('-D, --debug', 'turn on debug level logging', function() { require('./logger').setDebugEnabled(true) })
+    .option('-T, --no-timestamp', 'do not issue timestamps in logging', function() { require('./logger').setTimestampEnabled(false) })
+    .option('-C, --color', 'force color in logging', function() { require('./logger').forceColor() })
     .option('-I, --insecure', 'allow unauthenticated requests (for easier hacking)', function() { insecureAccess = true })
     .parse(process.argv);
 
   // Initialize HAP-NodeJS with a custom persist directory
   hap.init(User.persistPath());
-  
+
   var server = new Server(insecureAccess);
 
   var signals = { 'SIGINT': 2, 'SIGTERM': 15 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,14 +6,28 @@ var util = require('util');
 module.exports = {
   Logger: Logger,
   setDebugEnabled: setDebugEnabled,
+  setTimestampEnabled: setTimestampEnabled,
+  forceColor: forceColor,
   _system: new Logger() // system logger, for internal use only
 }
 
 var DEBUG_ENABLED = false;
+var TIMESTAMP_ENABLED = true;
 
 // Turns on debug level logging
 function setDebugEnabled(enabled) {
   DEBUG_ENABLED = enabled;
+}
+
+// Turns off timestamps in log messages
+function setTimestampEnabled(timestamp) {
+  TIMESTAMP_ENABLED = timestamp;
+}
+
+// Force color in log messages, even when output is redirected
+function forceColor() {
+  chalk.enabled = true;
+  chalk.level = 1;
 }
 
 // global cache of logger instances by plugin name
@@ -66,8 +80,10 @@ Logger.prototype.log = function(level, msg) {
     msg = chalk.cyan("[" + this.prefix +  "]") + " " + msg;
 
   // prepend timestamp
-  var date = new Date();
-  msg =  chalk.white("[" + date.toLocaleString() + "]") + " " + msg;
+  if (TIMESTAMP_ENABLED) {
+    var date = new Date();
+    msg =  chalk.white("[" + date.toLocaleString() + "]") + " " + msg;
+  }
 
   func(msg);
 }


### PR DESCRIPTION
New command line options to customise logging functionality, see #1882:
- `-T`: suppress timestamps.  Particularly useful when running homebridge from `systemctl` or similar, redirecting the log to syslog, which already provides timestamps;
- `-C`: force coloured messages.  Useful when redirecting the log to a file or syslog, which would otherwise suppress colors.  Use `journalctl -a` to see the colours in syslog.