### PR TITLE
Handle both CommonJS and ES6 style module.exports.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -69,7 +69,14 @@ Plugin.prototype.load = function(options) {
   var mainPath = path.join(this.pluginPath, main);
 
   // try to require() it and grab the exported initialization hook
-  this.initializer = require(mainPath);
+  var pluginModules = require(mainPath);
+  if (typeof pluginModules === "function") {
+    this.initializer = pluginModules;
+  } else if (pluginModules && typeof pluginModules.default === "function") {
+    this.initializer = pluginModules.default;
+  } else {
+    throw new Error("Plugin " + this.pluginPath + " does not export a initializer function from main.");
+  }
 }
 
 Plugin.loadPackageJSON = function(pluginPath) {


### PR DESCRIPTION
In ES6/Babel 6 doing `export default function() {}` results in that
function being assigned to `module.exports.default` rather than to
`module.exports` directly as it does in CommonJS.

Currently the Homebridge platform plugin setup expects the initializer
function to be available from `require` in CommonJS style, and so it
breaks for projects using ES6. Additionally there is currently no
helpful error when this happens; Homebridge fails to boot with Node
reporting a JS type error that `plugin.initializer` is not a function.

Here I've retained backwards compatibility with CommonJS style, but
check to see if `module.exports` is a function itself or if we need to
access `module.exports.default`. If neither is a function, we throw a
helpful error.