### PR TITLE
Resolve custom config path so plugins extracting it can work with it

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -43,5 +43,5 @@ User.cachedAccessoryPath = function() {
 }
 
 User.setStoragePath = function(path) {
-  customStoragePath = path;
+  customStoragePath = path.resolve(path);
 }

--- a/lib/user.js
+++ b/lib/user.js
@@ -42,6 +42,6 @@ User.cachedAccessoryPath = function() {
   return path.join(User.storagePath(), "accessories");
 }
 
-User.setStoragePath = function(path) {
-  customStoragePath = path.resolve(path);
+User.setStoragePath = function(storagePath) {
+  customStoragePath = path.resolve(storagePath);
 }


### PR DESCRIPTION
If running `homebridge -U ./`, the plugin `homebridge-config-ui-x` doesn't work because it cannot find the config.json file.

Running it with an absolute path does work instead. So I suggest converting the relative path into an absolute one so when plugins request the config path, they'll get the absolute version of it.