### PR TITLE
Clean orphaned cached accessories / handle uncaught exceptions

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,6 +12,7 @@ module.exports = function() {
   var cleanCachedAccessories = false
   var insecureAccess = false;
   var hideQRCode = false;
+  var shuttingDown = false;
 
   program
     .version(version)
@@ -33,6 +34,11 @@ module.exports = function() {
   var signals = { 'SIGINT': 2, 'SIGTERM': 15 };
   Object.keys(signals).forEach(function (signal) {
     process.on(signal, function () {
+      if (shuttingDown) {
+        return
+      }
+      shuttingDown = true;
+
       log.info("Got %s, shutting down Homebridge...", signal);
 
       server._teardown();
@@ -41,6 +47,13 @@ module.exports = function() {
       }, 5000)
       server._api.emit('shutdown')
     });
+  });
+
+  process.on('uncaughtException', function(error) {
+    log.error(error.stack);
+    if (!shuttingDown) {
+      process.kill(process.pid, 'SIGTERM');
+    }
   });
 
   server.run();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,25 +9,26 @@ var log = require("./logger")._system;
 'use strict';
 
 module.exports = function() {
-
+  var cleanCachedAccessories = false
   var insecureAccess = false;
   var hideQRCode = false;
 
   program
     .version(version)
+    .option('-C, --color', 'force color in logging', function() { require('./logger').forceColor(); })
+    .option('-D, --debug', 'turn on debug level logging', function() { require('./logger').setDebugEnabled(true); })
+    .option('-I, --insecure', 'allow unauthenticated requests (for easier hacking)', function() { insecureAccess = true; })
     .option('-P, --plugin-path [path]', 'look for plugins installed at [path] as well as the default locations ([path] can also point to a single plugin)', function(p) { Plugin.addPluginPath(p); })
+    .option('-Q, --no-qrcode', 'do not issue QRcode in logging', function() { hideQRCode = true; })
+    .option('-R, --remove-orphans', 'remove cached accessories for which plugin is not loaded', function() { cleanCachedAccessories = true; })
+    .option('-T, --no-timestamp', 'do not issue timestamps in logging', function() { require('./logger').setTimestampEnabled(false); })
     .option('-U, --user-storage-path [path]', 'look for homebridge user files at [path] instead of the default location (~/.homebridge)', function(p) { User.setStoragePath(p); })
-    .option('-D, --debug', 'turn on debug level logging', function() { require('./logger').setDebugEnabled(true) })
-    .option('-T, --no-timestamp', 'do not issue timestamps in logging', function() { require('./logger').setTimestampEnabled(false) })
-    .option('-Q, --no-qrcode', 'do not issue QRcode in logging', function() { hideQRCode = true })
-    .option('-C, --color', 'force color in logging', function() { require('./logger').forceColor() })
-    .option('-I, --insecure', 'allow unauthenticated requests (for easier hacking)', function() { insecureAccess = true })
     .parse(process.argv);
 
   // Initialize HAP-NodeJS with a custom persist directory
   hap.init(User.persistPath());
 
-  var server = new Server({insecureAccess:insecureAccess,hideQRCode:hideQRCode});
+  var server = new Server({cleanCachedAccessories:cleanCachedAccessories, insecureAccess:insecureAccess, hideQRCode:hideQRCode});
 
   var signals = { 'SIGINT': 2, 'SIGTERM': 15 };
   Object.keys(signals).forEach(function (signal) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -57,6 +57,7 @@ function Server(opts) {
   this._plugins = this._loadPlugins(); // plugins[name] = Plugin instance
   this._cachedPlatformAccessories = this._loadCachedPlatformAccessories();
   this._bridge = this._createBridge();
+  this._cleanCachedAccessories = opts.cleanCachedAccessories || false;
   this._hideQRCode = opts.hideQRCode || false;
 
   this._externalPorts = this._config.ports;
@@ -265,7 +266,7 @@ Server.prototype._computeActivePluginList = function() {
   }
 
   var activePlugins = {};
-  
+
   for (var i=0; i<this._config.plugins.length; i++) {
     var pluginName = this._config.plugins[i];
     activePlugins[pluginName] = true;
@@ -365,6 +366,7 @@ Server.prototype._loadDynamicPlatforms = function() {
 }
 
 Server.prototype._configCachedPlatformAccessories = function() {
+  var verifiedAccessories = [];
   for (var index in this._cachedPlatformAccessories) {
     var accessory = this._cachedPlatformAccessories[index];
 
@@ -384,11 +386,16 @@ Server.prototype._configCachedPlatformAccessories = function() {
       platformInstance.configureAccessory(accessory);
     } else {
       console.log("Failed to find plugin to handle accessory " + accessory.displayName);
+      if (this._cleanCachedAccessories) {
+        console.log("Removing orphaned accessory " + accessory.displayName);
+        continue;
+      }
     }
-
+    verifiedAccessories.push(accessory);
     accessory._prepareAssociatedHAPAccessory();
     this._bridge.addBridgedAccessory(accessory._associatedHAPAccessory);
   }
+  this._cachedPlatformAccessories = verifiedAccessories;
 }
 
 Server.prototype._loadPlatformAccessories = function(platformInstance, log, platformType) {
@@ -547,7 +554,7 @@ Server.prototype._handlePublishExternalAccessories = function(accessories) {
 
     (function(name){
       hapAccessory.on('listening', function(port) {
-  
+
           log.info("%s is running on port %s.", name, port);
           log.info("Please add [%s] manually in Home app. Setup Code: %s", name, accessoryPin);
       })
@@ -661,7 +668,7 @@ Server.prototype._printPin = function(pin) {
   if(!this._hideQRCode)
     console.log("Or enter this code with your HomeKit app on your iOS device to pair with Homebridge:");
   else
-    console.log("Enter this code with your HomeKit app on your iOS device to pair with Homebridge:");  
+    console.log("Enter this code with your HomeKit app on your iOS device to pair with Homebridge:");
   console.log(chalk.black.bgWhite("                       "));
   console.log(chalk.black.bgWhite("    ┌────────────┐     "));
   console.log(chalk.black.bgWhite("    │ " + pin + " │     "));


### PR DESCRIPTION
See #2120:
- Add `-R` or `--remove-orphans` command line option;
- Clean orphaned cached accessores, for which no plugin was loaded, when `-R` was specified on the command line.

Handle uncaught exceptions to do a clean shutdown of homebridge instead of crashing NodeJS.

@nfarina, @KhaosT, please review.  Some technical notes:
- This change will unconditionally remove cached "stuff" that is not a `PlatformAccessory`.  I could add the check to do this only when `-R` was specified, but I see no reason why you would want to keep this "stuff" in the cache;
- I daren't remove elements from the `_cachedPlatformAccessories` while looping over them, hence the build up of `verifiedAccessories` to replace `_cachedPlatformAccessories` after the loop.