### PR TITLE
Node.js 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "homebridge": "bin/homebridge"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=4.3.2"
   },
   "preferGlobal": true,
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.4.50",
+    "hap-nodejs": "0.4.51",
     "semver": "5.0.3",
     "node-persist": "^0.0.8",
     "qrcode-terminal": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "homebridge": "bin/homebridge"
   },
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=8.0.0"
   },
   "preferGlobal": true,
   "dependencies": {
     "chalk": "^1.1.1",
     "commander": "2.8.1",
-    "hap-nodejs": "0.4.49",
+    "hap-nodejs": "0.4.50",
     "semver": "5.0.3",
     "node-persist": "^0.0.8",
     "qrcode-terminal": "^0.11.0"


### PR DESCRIPTION
To support Node.js 12, the underlying library HAP-NodeJS swapped library used for curve25519 and ed25519 to `libsodium.js`. Due to the introduction of async/await, I bumped node dependency to 8.0.0 or later.

Any concerns? @nfarina @ebaauw 